### PR TITLE
Fix CMake order file generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,7 +596,7 @@ set(CLANG_ORDER_FILE ${CMAKE_CURRENT_BINARY_DIR}/clang.order CACHE FILEPATH
   "Order file to use when compiling clang in order to improve startup time.")
 
 if(CLANG_ORDER_FILE AND NOT EXISTS ${CLANG_ORDER_FILE})
-  string(FIND CLANG_ORDER_FILE "${CMAKE_CURRENT_BINARY_DIR}" PATH_START)
+  string(FIND "${CLANG_ORDER_FILE}" "${CMAKE_CURRENT_BINARY_DIR}" PATH_START)
   if(PATH_START EQUAL 0)
     file(WRITE ${CLANG_ORDER_FILE} "\n")
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,8 +595,13 @@ endif()
 set(CLANG_ORDER_FILE ${CMAKE_CURRENT_BINARY_DIR}/clang.order CACHE FILEPATH
   "Order file to use when compiling clang in order to improve startup time.")
 
-if(NOT EXISTS ${CLANG_ORDER_FILE})
-  execute_process(COMMAND ${CMAKE_COMMAND} -E touch ${CLANG_ORDER_FILE})
+if(CLANG_ORDER_FILE AND NOT EXISTS ${CLANG_ORDER_FILE})
+  string(FIND CLANG_ORDER_FILE "${CMAKE_CURRENT_BINARY_DIR}" PATH_START)
+  if(PATH_START EQUAL 0)
+    file(WRITE ${CLANG_ORDER_FILE} "\n")
+  else()
+    message(FATAL_ERROR "Specified order file '${CLANG_ORDER_FILE}' does not exist.")
+  endif()
 endif()
 
 if (CLANG_BUILT_STANDALONE OR CMAKE_VERSION VERSION_EQUAL 3 OR

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -89,12 +89,24 @@ if (APPLE)
   set(TOOL_INFO_BUILD_VERSION)
 endif()
 
-check_cxx_compiler_flag("-Wl,-order_file,${CLANG_ORDER_FILE}"
-  LINKER_HAS_ORDER_FILE_FLAG)
+if(CLANG_ORDER_FILE)
+  include(CMakePushCheckState)
 
-if(LINKER_HAS_ORDER_FILE_FLAG AND CLANG_ORDER_FILE)
-  target_link_libraries(clang "-Wl,-order_file,${CLANG_ORDER_FILE}")
-  set_target_properties(clang PROPERTIES LINK_DEPENDS ${CLANG_ORDER_FILE})
+  function(check_linker_flag flag out_var)
+    cmake_push_check_state()
+    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${flag}")
+    check_cxx_compiler_flag("" ${out_var})
+    cmake_pop_check_state()
+  endfunction()
+
+  # This is a test to ensure the actual order file works with the linker.
+  check_linker_flag("-Wl,-order_file,${CLANG_ORDER_FILE}"
+    LINKER_ORDER_FILE_WORKS)
+  
+  if(LINKER_ORDER_FILE_WORKS)
+    target_link_libraries(clang "-Wl,-order_file,${CLANG_ORDER_FILE}")
+    set_target_properties(clang PROPERTIES LINK_DEPENDS ${CLANG_ORDER_FILE})
+  endif()
 endif()
 
 if(WITH_POLLY AND LINK_POLLY_INTO_TOOLS)


### PR DESCRIPTION
This group of commits makes sure that we can properly perform incremental compilation builds on linux without hitting an order file generation bug.
