### PR TITLE
Enable Objective-C fixed enums feature for Swift

### DIFF
--- a/lib/Lex/PPMacroExpansion.cpp
+++ b/lib/Lex/PPMacroExpansion.cpp
@@ -1040,6 +1040,12 @@ static void ComputeDATE_TIME(SourceLocation &DATELoc, SourceLocation &TIMELoc,
 }
 
 
+static bool hasModuleFeature(StringRef Feature, const LangOptions &LangOpts) {
+    return std::find(LangOpts.ModuleFeatures.begin(),
+                     LangOpts.ModuleFeatures.end(),
+                     Feature) != LangOpts.ModuleFeatures.end();
+}
+
 /// HasFeature - Return true if we recognize and implement the feature
 /// specified by the identifier as a standard language feature.
 static bool HasFeature(const Preprocessor &PP, const IdentifierInfo *II) {
@@ -1093,7 +1099,8 @@ static bool HasFeature(const Preprocessor &PP, const IdentifierInfo *II) {
       .Case("objc_arc", LangOpts.ObjCAutoRefCount)
       .Case("objc_arc_weak", LangOpts.ObjCWeak)
       .Case("objc_default_synthesize_properties", LangOpts.ObjC2)
-      .Case("objc_fixed_enum", LangOpts.ObjC2)
+      .Case("objc_fixed_enum", LangOpts.ObjC2 ||
+            hasModuleFeature("swift", LangOpts))
       .Case("objc_instancetype", LangOpts.ObjC2)
       .Case("objc_kindof", LangOpts.ObjC2)
       .Case("objc_modules", LangOpts.ObjC2 && LangOpts.Modules)

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3696,6 +3696,12 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
                                    T.getCloseLocation());
 }
 
+static bool hasModuleFeature(StringRef Feature, const LangOptions &LangOpts) {
+    return std::find(LangOpts.ModuleFeatures.begin(),
+                     LangOpts.ModuleFeatures.end(),
+                     Feature) != LangOpts.ModuleFeatures.end();
+}
+
 /// ParseEnumSpecifier
 ///       enum-specifier: [C99 6.7.2.2]
 ///         'enum' identifier[opt] '{' enumerator-list '}'
@@ -3778,7 +3784,7 @@ void Parser::ParseEnumSpecifier(SourceLocation StartLoc, DeclSpec &DS,
 
   bool AllowFixedUnderlyingType = AllowDeclaration &&
     (getLangOpts().CPlusPlus11 || getLangOpts().MicrosoftExt ||
-     getLangOpts().ObjC2);
+     getLangOpts().ObjC2 || hasModuleFeature("swift", getLangOpts()));
 
   CXXScopeSpec &SS = DS.getTypeSpecScope();
   if (getLangOpts().CPlusPlus) {


### PR DESCRIPTION
This patch enables CF_ENUM and CF_OPTIONS on non-Darwin targets

cc/ @tienex
