### PR TITLE
In x86-64 Cygwin, USER_LABEL_PREFIX is empty

### DIFF
--- a/lib/Basic/Targets.cpp
+++ b/lib/Basic/Targets.cpp
@@ -4138,6 +4138,7 @@ public:
       : X86_64TargetInfo(Triple) {
     TLSSupported = false;
     WCharType = UnsignedShort;
+    this->UserLabelPrefix = "";
   }
   void getTargetDefines(const LangOptions &Opts,
                         MacroBuilder &Builder) const override {


### PR DESCRIPTION
In Cygwin 64, the gcc compiler has not the underscore prefix as follows.

```
$ gcc -E -o - -dM -x c - < /dev/null | grep  USER
#define __USER_LABEL_PREFIX__

$ clang-3.5.2 -E -o - -dM -x c - < /dev/null | grep  USER
#define __USER_LABEL_PREFIX__ _
```

This macro is rarely used, but some library functions could not be linked. (ex. `basename()`, BSD's `qsort_r()`)
