### PR TITLE
Cherry-pick fix for swift_newtype attribute doc from upstream-with-swift

### DIFF
--- a/include/clang/Basic/AttrDocs.td
+++ b/include/clang/Basic/AttrDocs.td
@@ -1820,6 +1820,7 @@ All of these conventions except ``none`` require the function to have an error p
 
 def SwiftNewtypeDocs : Documentation {
   let Category = SwiftDocs;
+  let Heading = "swift_newtype";
   let Content = [{
 The ``swift_newtype`` attribute indicates that the typedef to which the attribute appertains is imported as a new Swift type of the typedef's name.
 * ``swift_newtype(struct)`` means that a Swift struct will be created for this typedef.


### PR DESCRIPTION
The clang documentation for attributes does not build on the swift-3.0-branch because of a missing "Heading" field. Michael Ilseman fixed this back in April on the upstream-with-swift branch. This pull request cherry-picks that fix to the release branch. rdar://problem/26560738
