### PR TITLE
Avoid accessing an invalid PresumedLoc.

### DIFF
--- a/lib/Frontend/DiagnosticRenderer.cpp
+++ b/lib/Frontend/DiagnosticRenderer.cpp
@@ -618,7 +618,7 @@ DiagnosticNoteRenderer::emitBuildingModuleLocation(SourceLocation Loc,
   // Generate a note indicating the include location.
   SmallString<200> MessageStorage;
   llvm::raw_svector_ostream Message(MessageStorage);
-  if (PLoc.getFilename())
+  if (PLoc.isValid())
     Message << "while building module '" << ModuleName << "' imported from "
             << PLoc.getFilename() << ':' << PLoc.getLine() << ":";
   else


### PR DESCRIPTION
DiagnosticNoteRenderer asserts trying to emit its "while building
module Foo imported from bar.h:5" note when the presumed location
of the import is invalid. This assertion was added in r267914,
where most uses of 'getFilename' were updated to test 'isValid'
instead. This one must have been missed.

I can't come up with a test because this location is always valid
in C-based code, but external clients that manually import modules
(*cough*Swift*cough*) sometimes provide invalid SourceLocations.

rdar://problem/26099576
