### PR TITLE
[API Notes] Add support for parameters, 'noescape' attribute <rdar://problem/27256643>

### DIFF
--- a/lib/APINotes/APINotesFormat.h
+++ b/lib/APINotes/APINotesFormat.h
@@ -35,7 +35,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// API notes file minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t VERSION_MINOR = 12;  // SwiftPrivate
+const uint16_t VERSION_MINOR = 13;  // Function/method parameters
 
 using IdentifierID = Fixnum<31>;
 using IdentifierIDField = BCVBR<16>;

--- a/lib/APINotes/APINotesReader.cpp
+++ b/lib/APINotes/APINotesReader.cpp
@@ -228,6 +228,22 @@ namespace {
       = endian::readNext<uint8_t, little, unaligned>(data);
     info.NullabilityPayload
       = endian::readNext<uint64_t, little, unaligned>(data);
+
+    unsigned numParams = endian::readNext<uint16_t, little, unaligned>(data);
+    while (numParams > 0) {
+      uint8_t payload = endian::readNext<uint8_t, little, unaligned>(data);
+
+      ParamInfo pi;
+      uint8_t nullabilityValue = payload & 0x3; payload >>= 2;
+      if (payload & 0x01)
+        pi.setNullabilityAudited(static_cast<NullabilityKind>(nullabilityValue));
+      payload >>= 1;
+      pi.setNoEscape(payload & 0x01);
+      payload >>= 1; assert(payload == 0 && "Bad API notes");
+
+      info.Params.push_back(pi);
+      --numParams;
+    }
   }
 
   /// Used to deserialize the on-disk Objective-C method table.

--- a/lib/APINotes/APINotesWriter.cpp
+++ b/lib/APINotes/APINotesWriter.cpp
@@ -494,7 +494,8 @@ namespace {
   /// Retrieve the serialized size of the given FunctionInfo, for use in
   /// on-disk hash tables.
   static unsigned getFunctionInfoSize(const FunctionInfo &info) {
-    return 2 + sizeof(uint64_t) + getCommonEntityInfoSize(info);
+    return 2 + sizeof(uint64_t) + getCommonEntityInfoSize(info) + 
+           2 + info.Params.size() * 1;
   }
 
   /// Emit a serialized representation of the function information.
@@ -505,6 +506,20 @@ namespace {
     writer.write<uint8_t>(info.NullabilityAudited);
     writer.write<uint8_t>(info.NumAdjustedNullable);
     writer.write<uint64_t>(info.NullabilityPayload);
+
+    // Parameters.
+    writer.write<uint16_t>(info.Params.size());
+    for (const auto &pi : info.Params) {
+      uint8_t payload = pi.isNoEscape();
+
+      auto nullability = pi.getNullability();
+      payload = (payload << 1) | nullability.hasValue();
+
+      payload = payload << 2;
+      if (nullability)
+        payload |= static_cast<uint8_t>(*nullability);
+      writer.write<uint8_t>(payload);
+    }
   }
 
   /// Used to serialize the on-disk Objective-C method table.

--- a/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -166,9 +166,17 @@ namespace {
     NullabilityKind::NonNull;
   typedef std::vector<clang::NullabilityKind> NullabilitySeq;
 
+  struct Param {
+    unsigned Position;
+    bool NoEscape = false;
+    llvm::Optional<NullabilityKind> Nullability;
+  };
+  typedef std::vector<Param> ParamsSeq;
+
   struct Method {
     StringRef Selector;
     MethodKind Kind;
+    ParamsSeq Params;
     NullabilitySeq Nullability;
     llvm::Optional<NullabilityKind> NullabilityOfRet;
     AvailabilityItem Availability;
@@ -205,6 +213,7 @@ namespace {
 
   struct Function {
     StringRef Name;
+    ParamsSeq Params;
     NullabilitySeq Nullability;
     llvm::Optional<NullabilityKind> NullabilityOfRet;
     AvailabilityItem Availability;
@@ -272,6 +281,7 @@ namespace {
 LLVM_YAML_IS_FLOW_SEQUENCE_VECTOR(clang::NullabilityKind)
 LLVM_YAML_IS_SEQUENCE_VECTOR(Method)
 LLVM_YAML_IS_SEQUENCE_VECTOR(Property)
+LLVM_YAML_IS_SEQUENCE_VECTOR(Param)
 LLVM_YAML_IS_SEQUENCE_VECTOR(Class)
 LLVM_YAML_IS_SEQUENCE_VECTOR(Function)
 LLVM_YAML_IS_SEQUENCE_VECTOR(GlobalVariable)
@@ -323,6 +333,16 @@ namespace llvm {
     };
 
     template <>
+    struct MappingTraits<Param> {
+      static void mapping(IO &io, Param& p) {
+        io.mapRequired("Position",        p.Position);
+        io.mapOptional("Nullability",     p.Nullability, 
+                                          AbsentNullability);
+        io.mapOptional("NoEscape",        p.NoEscape);
+      }
+    };
+
+    template <>
     struct MappingTraits<Property> {
       static void mapping(IO &io, Property& p) {
         io.mapRequired("Name",            p.Name);
@@ -340,6 +360,7 @@ namespace llvm {
       static void mapping(IO &io, Method& m) {
         io.mapRequired("Selector",        m.Selector);
         io.mapRequired("MethodKind",      m.Kind);
+        io.mapOptional("Parameters",      m.Params);
         io.mapOptional("Nullability",     m.Nullability);
         io.mapOptional("NullabilityOfRet",  m.NullabilityOfRet,
                                             AbsentNullability);
@@ -374,6 +395,7 @@ namespace llvm {
     struct MappingTraits<Function> {
       static void mapping(IO &io, Function& f) {
         io.mapRequired("Name",             f.Name);
+        io.mapOptional("Parameters",       f.Params);
         io.mapOptional("Nullability",      f.Nullability);
         io.mapOptional("NullabilityOfRet", f.NullabilityOfRet,
                                            AbsentNullability);
@@ -527,6 +549,20 @@ namespace {
       return false;
     }
 
+    void convertParams(const ParamsSeq &params, FunctionInfo &outInfo) {
+      for (const auto &p : params) {
+        ParamInfo pi;
+        if (p.Nullability)
+          pi.setNullabilityAudited(*p.Nullability);
+        pi.setNoEscape(p.NoEscape);
+
+        while (outInfo.Params.size() <= p.Position) {
+          outInfo.Params.push_back(ParamInfo());
+        }
+        outInfo.Params[p.Position] |= pi;
+      }
+    }
+
     void convertNullability(const NullabilitySeq &nullability,
                             Optional<NullabilityKind> nullabilityOfRet,
                             FunctionInfo &outInfo,
@@ -609,6 +645,9 @@ namespace {
       mInfo.Required = meth.Required;
       if (meth.FactoryAsInit != FactoryAsInitKind::Infer)
         mInfo.setFactoryAsInitKind(meth.FactoryAsInit);
+
+      // Translate parameter information.
+      convertParams(meth.Params, mInfo);
 
       // Translate nullability info.
       convertNullability(meth.Nullability, meth.NullabilityOfRet,
@@ -744,6 +783,7 @@ namespace {
         convertAvailability(function.Availability, info, function.Name);
         info.SwiftPrivate = function.SwiftPrivate;
         info.SwiftName = function.SwiftName;
+        convertParams(function.Params, info);
         convertNullability(function.Nullability,
                            function.NullabilityOfRet,
                            info, function.Name);
@@ -924,6 +964,19 @@ namespace {
       }
     }
 
+    /// Map parameter information for a function.
+    void handleParameters(ParamsSeq &params,
+                          const FunctionInfo &info) {
+      unsigned position = 0;
+      for (const auto &pi: info.Params) {
+        Param p;
+        p.Position = position++;
+        p.Nullability = pi.getNullability();
+        p.NoEscape = pi.isNoEscape();
+        params.push_back(p);
+      }
+    }
+
     /// Map nullability information for a function.
     void handleNullability(NullabilitySeq &nullability,
                            llvm::Optional<NullabilityKind> &nullabilityOfRet,
@@ -967,6 +1020,7 @@ namespace {
       method.Kind = isInstanceMethod ? MethodKind::Instance : MethodKind::Class;
 
       handleCommon(method, info);
+      handleParameters(method.Params, info);
       handleNullability(method.Nullability, method.NullabilityOfRet, info,
                         selector.count(':'));
       method.FactoryAsInit = info.getFactoryAsInitKind();
@@ -1003,6 +1057,7 @@ namespace {
       Function function;
       function.Name = name;
       handleCommon(function, info);
+      handleParameters(function.Params, info);
       if (info.NumAdjustedNullable > 0)
         handleNullability(function.Nullability, function.NullabilityOfRet,
                           info, info.NumAdjustedNullable-1);

--- a/test/APINotes/Inputs/APINotes/HeaderLib.apinotes
+++ b/test/APINotes/Inputs/APINotes/HeaderLib.apinotes
@@ -9,6 +9,13 @@ Functions:
   - Name: do_something_with_pointers
     NullabilityOfRet: O
     Nullability: [ N, O ]
+  - Name: take_pointer_and_int
+    Parameters:
+      - Position: 0
+        Nullability: N
+        NoEscape: true
+      - Position: 1
+        NoEscape: true
     
 Globals:
   - Name: global_int

--- a/test/APINotes/Inputs/Headers/HeaderLib.h
+++ b/test/APINotes/Inputs/Headers/HeaderLib.h
@@ -13,4 +13,6 @@ void do_something_with_pointers(int *ptr1, int *ptr2);
 typedef int unavailable_typedef;
 struct unavailable_struct { int x, y, z; };
 
+void take_pointer_and_int(int *ptr1, int value);
+
 #endif

--- a/test/APINotes/Inputs/roundtrip.apinotes
+++ b/test/APINotes/Inputs/roundtrip.apinotes
@@ -67,6 +67,13 @@ Classes:
         SwiftName:       ''
       - Selector:        'addSubview:positioned:relativeTo:'
         MethodKind:      Instance
+        Parameters:      
+          - Position:        0
+            NoEscape:        false
+          - Position:        1
+            NoEscape:        false
+          - Position:        2
+            NoEscape:        true
         Nullability:     [ N, N, O ]
         NullabilityOfRet: N
         Availability:    available

--- a/test/APINotes/nullability.c
+++ b/test/APINotes/nullability.c
@@ -8,6 +8,7 @@ int main() {
   int i = 0;
   do_something_with_pointers(&i, 0);
   do_something_with_pointers(0, &i); // expected-warning{{null passed to a callee that requires a non-null argument}}
+  take_pointer_and_int(0, 0); // expected-warning{{null passed to a callee that requires a non-null argument}}
 
   float *fp = global_int; // expected-warning{{incompatible pointer types initializing 'float *' with an expression of type 'int * _Nonnull'}}
   return 0;


### PR DESCRIPTION
Support for adding the 'noescape' attribute to function/method parameters via API notes.

(cherry picked from commit 54a75ad253996e21d65ae464b2611b57ef8c7335)
