### PR TITLE
[API Notes] Add basic support for versioned API notes

### DIFF
--- a/include/clang/APINotes/APINotesManager.h
+++ b/include/clang/APINotes/APINotesManager.h
@@ -16,6 +16,7 @@
 
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/Module.h"
+#include "clang/Basic/VersionTuple.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PointerUnion.h"
@@ -54,6 +55,9 @@ class APINotesManager {
   /// Whether to implicitly search for API notes files based on the
   /// source file from which an entity was declared.
   bool ImplicitAPINotes;
+
+  /// The Swift version to use when interpreting versioned API notes.
+  VersionTuple SwiftVersion;
 
   /// API notes readers for the current module.
   ///
@@ -108,6 +112,11 @@ class APINotesManager {
 public:
   APINotesManager(SourceManager &sourceMgr, const LangOptions &langOpts);
   ~APINotesManager();
+
+  /// Set the Swift version to use when filtering API notes.
+  void setSwiftVersion(VersionTuple swiftVersion) {
+    SwiftVersion = swiftVersion;
+  }
 
   /// Load the API notes for the current module.
   ///

--- a/include/clang/APINotes/APINotesOptions.h
+++ b/include/clang/APINotes/APINotesOptions.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CLANG_APINOTES_APINOTESOPTIONS_H
 #define LLVM_CLANG_APINOTES_APINOTESOPTIONS_H
 
+#include "clang/Basic/VersionTuple.h"
 #include <string>
 #include <vector>
 
@@ -23,6 +24,9 @@ namespace clang {
 /// notes are found and handled.
 class APINotesOptions {
 public:
+  /// The Swift version which should be used for API notes.
+  VersionTuple SwiftVersion;
+
   /// The set of search paths where we API notes can be found for
   /// particular modules.
   ///

--- a/include/clang/APINotes/APINotesReader.h
+++ b/include/clang/APINotes/APINotesReader.h
@@ -17,6 +17,7 @@
 #define LLVM_CLANG_API_NOTES_READER_H
 
 #include "clang/APINotes/Types.h"
+#include "clang/Basic/VersionTuple.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include <memory>
@@ -65,21 +66,33 @@ public:
   /// Retrieve the module options
   ModuleOptions getModuleOptions() const;
 
+  /// Look for the context ID of the given Objective-C class.
+  ///
+  /// \param name The name of the class we're looking for.
+  ///
+  /// \returns The ID, if known.
+  Optional<ContextID> lookupObjCClassID(StringRef name);
+
   /// Look for information regarding the given Objective-C class.
   ///
   /// \param name The name of the class we're looking for.
   ///
-  /// \returns The ID and information about the class, if known.
-  Optional<std::pair<ContextID, ObjCContextInfo>>
-  lookupObjCClass(StringRef name);
+  /// \returns The information about the class, if known.
+  Optional<ObjCContextInfo> lookupObjCClassInfo(StringRef name);
+
+  /// Look for the context ID of the given Objective-C protocol.
+  ///
+  /// \param name The name of the protocol we're looking for.
+  ///
+  /// \returns The ID of the protocol, if known.
+  Optional<ContextID> lookupObjCProtocolID(StringRef name);
 
   /// Look for information regarding the given Objective-C protocol.
   ///
   /// \param name The name of the protocol we're looking for.
   ///
-  /// \returns The ID and information about the protocol, if known.
-  Optional<std::pair<ContextID, ObjCContextInfo>>
-  lookupObjCProtocol(StringRef name);
+  /// \returns The information about the protocol, if known.
+  Optional<ObjCContextInfo> lookupObjCProtocolInfo(StringRef name);
 
   /// Look for information regarding the given Objective-C property in
   /// the given context.
@@ -88,6 +101,7 @@ public:
   /// \param name The name of the property we're looking for.
   /// \param isInstance Whether we are looking for an instance property (vs.
   /// a class property).
+  /// \param swiftVersion The Swift version to filter for, if any.
   ///
   /// \returns Information about the property, if known.
   Optional<ObjCPropertyInfo> lookupObjCProperty(ContextID contextID,
@@ -149,39 +163,48 @@ public:
 
     /// Visit an Objective-C class.
     virtual void visitObjCClass(ContextID contextID, StringRef name,
-                                const ObjCContextInfo &info);
+                                const ObjCContextInfo &info,
+                                VersionTuple swiftVersion);
 
     /// Visit an Objective-C protocol.
     virtual void visitObjCProtocol(ContextID contextID, StringRef name,
-                                   const ObjCContextInfo &info);
+                                   const ObjCContextInfo &info,
+                                   VersionTuple swiftVersion);
 
     /// Visit an Objective-C method.
     virtual void visitObjCMethod(ContextID contextID, StringRef selector,
                                  bool isInstanceMethod,
-                                 const ObjCMethodInfo &info);
+                                 const ObjCMethodInfo &info,
+                                 VersionTuple swiftVersion);
 
     /// Visit an Objective-C property.
     virtual void visitObjCProperty(ContextID contextID, StringRef name,
                                    bool isInstance,
-                                   const ObjCPropertyInfo &info);
+                                   const ObjCPropertyInfo &info,
+                                   VersionTuple swiftVersion);
 
     /// Visit a global variable.
     virtual void visitGlobalVariable(StringRef name,
-                                     const GlobalVariableInfo &info);
+                                     const GlobalVariableInfo &info,
+                                     VersionTuple swiftVersion);
 
     /// Visit a global function.
     virtual void visitGlobalFunction(StringRef name,
-                                     const GlobalFunctionInfo &info);
+                                     const GlobalFunctionInfo &info,
+                                     VersionTuple swiftVersion);
 
     /// Visit an enumerator.
     virtual void visitEnumConstant(StringRef name,
-                                   const EnumConstantInfo &info);
+                                   const EnumConstantInfo &info,
+                                   VersionTuple swiftVersion);
 
     /// Visit a tag.
-    virtual void visitTag(StringRef name, const TagInfo &info);
+    virtual void visitTag(StringRef name, const TagInfo &info,
+                          VersionTuple swiftVersion);
 
     /// Visit a typedef.
-    virtual void visitTypedef(StringRef name, const TypedefInfo &info);
+    virtual void visitTypedef(StringRef name, const TypedefInfo &info,
+                              VersionTuple swiftVersion);
   };
 
   /// Visit the contents of the API notes file, passing each entity to the

--- a/include/clang/APINotes/APINotesReader.h
+++ b/include/clang/APINotes/APINotesReader.h
@@ -33,7 +33,7 @@ class APINotesReader {
   Implementation &Impl;
 
   APINotesReader(llvm::MemoryBuffer *inputBuffer, bool ownsInputBuffer,
-                 bool &failed);
+                 VersionTuple swiftVersion, bool &failed);
 
 public:
   /// Create a new API notes reader from the given member buffer, which
@@ -41,14 +41,16 @@ public:
   ///
   /// \returns the new API notes reader, or null if an error occurred.
   static std::unique_ptr<APINotesReader>
-  get(std::unique_ptr<llvm::MemoryBuffer> inputBuffer);
+  get(std::unique_ptr<llvm::MemoryBuffer> inputBuffer,
+      VersionTuple swiftVersion);
 
   /// Create a new API notes reader from the given member buffer, which
   /// contains the contents of a binary API notes file.
   ///
   /// \returns the new API notes reader, or null if an error occurred.
   static std::unique_ptr<APINotesReader>
-  getUnmanaged(llvm::MemoryBuffer *inputBuffer);
+  getUnmanaged(llvm::MemoryBuffer *inputBuffer,
+               VersionTuple swiftVersion);
 
   ~APINotesReader();
 
@@ -66,6 +68,56 @@ public:
   /// Retrieve the module options
   ModuleOptions getModuleOptions() const;
 
+  /// Captures the completed versioned information for a particular part of
+  /// API notes, including both unversioned API notes and each versioned API
+  /// note for that particular entity.
+  template<typename T>
+  class VersionedInfo {
+    /// The complete set of results.
+    SmallVector<std::pair<VersionTuple, T>, 1> Results;
+
+    /// The index of the result that is the "selected" set based on the desired
+    /// Swift version, or \c Results.size() if nothing matched.
+    unsigned Selected;
+
+  public:
+    /// Form an empty set of versioned information.
+    VersionedInfo(llvm::NoneType) : Selected(0) { }
+    
+    /// Form a versioned info set given the desired version and a set of
+    /// results.
+    VersionedInfo(VersionTuple version,
+                  SmallVector<std::pair<VersionTuple, T>, 1> results);
+
+    /// Determine whether there is a result that should be applied directly
+    /// to the AST.
+    explicit operator bool() const { return Selected != size(); }
+
+    /// Retrieve the information to apply directly to the AST.
+    const T& operator*() const {
+      assert(*this && "No result to apply directly");
+      return (*this)[Selected].second;
+    }
+
+    /// Retrieve the selected index in the result set.
+    Optional<unsigned> getSelected() const {
+      if (Selected == Results.size()) return None;
+      return Selected;
+    }
+
+    /// Return the number of versioned results we know about.
+    unsigned size() const { return Results.size(); }
+
+    /// Access all versioned results.
+    const std::pair<VersionTuple, T> *begin() const { return Results.begin(); }
+    const std::pair<VersionTuple, T> *end() const { return Results.end(); }
+
+    /// Access a specific versioned result.
+    const std::pair<VersionTuple, T> &operator[](unsigned index) const {
+      return Results[index];
+    }
+  };
+
   /// Look for the context ID of the given Objective-C class.
   ///
   /// \param name The name of the class we're looking for.
@@ -78,7 +130,7 @@ public:
   /// \param name The name of the class we're looking for.
   ///
   /// \returns The information about the class, if known.
-  Optional<ObjCContextInfo> lookupObjCClassInfo(StringRef name);
+  VersionedInfo<ObjCContextInfo> lookupObjCClassInfo(StringRef name);
 
   /// Look for the context ID of the given Objective-C protocol.
   ///
@@ -92,7 +144,7 @@ public:
   /// \param name The name of the protocol we're looking for.
   ///
   /// \returns The information about the protocol, if known.
-  Optional<ObjCContextInfo> lookupObjCProtocolInfo(StringRef name);
+  VersionedInfo<ObjCContextInfo> lookupObjCProtocolInfo(StringRef name);
 
   /// Look for information regarding the given Objective-C property in
   /// the given context.
@@ -104,9 +156,9 @@ public:
   /// \param swiftVersion The Swift version to filter for, if any.
   ///
   /// \returns Information about the property, if known.
-  Optional<ObjCPropertyInfo> lookupObjCProperty(ContextID contextID,
-                                                StringRef name,
-                                                bool isInstance);
+  VersionedInfo<ObjCPropertyInfo> lookupObjCProperty(ContextID contextID,
+                                                     StringRef name,
+                                                     bool isInstance);
 
   /// Look for information regarding the given Objective-C method in
   /// the given context.
@@ -116,30 +168,30 @@ public:
   /// \param isInstanceMethod Whether we are looking for an instance method.
   ///
   /// \returns Information about the method, if known.
-  Optional<ObjCMethodInfo> lookupObjCMethod(ContextID contextID,
-                                            ObjCSelectorRef selector,
-                                            bool isInstanceMethod);
+  VersionedInfo<ObjCMethodInfo> lookupObjCMethod(ContextID contextID,
+                                                 ObjCSelectorRef selector,
+                                                 bool isInstanceMethod);
 
   /// Look for information regarding the given global variable.
   ///
   /// \param name The name of the global variable.
   ///
   /// \returns information about the global variable, if known.
-  Optional<GlobalVariableInfo> lookupGlobalVariable(StringRef name);
+  VersionedInfo<GlobalVariableInfo> lookupGlobalVariable(StringRef name);
 
   /// Look for information regarding the given global function.
   ///
   /// \param name The name of the global function.
   ///
   /// \returns information about the global function, if known.
-  Optional<GlobalFunctionInfo> lookupGlobalFunction(StringRef name);
+  VersionedInfo<GlobalFunctionInfo> lookupGlobalFunction(StringRef name);
 
   /// Look for information regarding the given enumerator.
   ///
   /// \param name The name of the enumerator.
   ///
   /// \returns information about the enumerator, if known.
-  Optional<EnumConstantInfo> lookupEnumConstant(StringRef name);
+  VersionedInfo<EnumConstantInfo> lookupEnumConstant(StringRef name);
 
   /// Look for information regarding the given tag
   /// (struct/union/enum/C++ class).
@@ -147,14 +199,14 @@ public:
   /// \param name The name of the tag.
   ///
   /// \returns information about the tag, if known.
-  Optional<TagInfo> lookupTag(StringRef name);
+  VersionedInfo<TagInfo> lookupTag(StringRef name);
 
   /// Look for information regarding the given typedef.
   ///
   /// \param name The name of the typedef.
   ///
   /// \returns information about the typedef, if known.
-  Optional<TypedefInfo> lookupTypedef(StringRef name);
+  VersionedInfo<TypedefInfo> lookupTypedef(StringRef name);
 
   /// Visitor used when walking the contents of the API notes file.
   class Visitor {

--- a/include/clang/APINotes/APINotesWriter.h
+++ b/include/clang/APINotes/APINotesWriter.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_CLANG_API_NOTES_WRITER_H
 #define LLVM_CLANG_API_NOTES_WRITER_H
 
+#include "clang/Basic/VersionTuple.h"
 #include "clang/APINotes/Types.h"
 
 namespace llvm {
@@ -46,23 +47,17 @@ public:
   /// Write the API notes data to the given stream.
   void writeToStream(llvm::raw_ostream &os);
 
-  /// Add information about a specific Objective-C class.
+  /// Add information about a specific Objective-C class or protocol.
   ///
-  /// \param name The name of this class.
-  /// \param info Information about this class.
+  /// \param name The name of this class/protocol.
+  /// \param isClass Whether this is a class (vs. a protocol).
+  /// \param info Information about this class/protocol.
   ///
-  /// \returns the ID of the class, which can be used to add properties and
-  /// methods to the class.
-  ContextID addObjCClass(StringRef name, const ObjCContextInfo &info);
-
-  /// Add information about a specific Objective-C protocol.
-  ///
-  /// \param name The name of this protocol.
-  /// \param info Information about this protocol.
-  ///
-  /// \returns the ID of the protocol, which can be used to add properties and
-  /// methods to the protocol.
-  ContextID addObjCProtocol(StringRef name, const ObjCContextInfo &info);
+  /// \returns the ID of the class or protocol, which can be used to add
+  /// properties and methods to the class/protocol.
+  ContextID addObjCContext(StringRef name, bool isClass,
+                           const ObjCContextInfo &info,
+                           VersionTuple swiftVersion);
 
   /// Add information about a specific Objective-C property.
   ///
@@ -71,7 +66,8 @@ public:
   /// \param info Information about this property.
   void addObjCProperty(ContextID contextID, StringRef name,
                        bool isInstanceProperty,
-                       const ObjCPropertyInfo &info);
+                       const ObjCPropertyInfo &info,
+                       VersionTuple swiftVersion);
 
   /// Add information about a specific Objective-C method.
   ///
@@ -81,37 +77,43 @@ public:
   /// (vs. a class method).
   /// \param info Information about this method.
   void addObjCMethod(ContextID contextID, ObjCSelectorRef selector,
-                     bool isInstanceMethod, const ObjCMethodInfo &info);
+                     bool isInstanceMethod, const ObjCMethodInfo &info,
+                     VersionTuple swiftVersion);
 
   /// Add information about a global variable.
   ///
   /// \param name The name of this global variable.
   /// \param info Information about this global variable.
-  void addGlobalVariable(StringRef name, const GlobalVariableInfo &info);
+  void addGlobalVariable(StringRef name, const GlobalVariableInfo &info,
+                         VersionTuple swiftVersion);
 
   /// Add information about a global function.
   ///
   /// \param name The name of this global function.
   /// \param info Information about this global function.
-  void addGlobalFunction(StringRef name, const GlobalFunctionInfo &info);
+  void addGlobalFunction(StringRef name, const GlobalFunctionInfo &info,
+                         VersionTuple swiftVersion);
 
   /// Add information about an enumerator.
   ///
   /// \param name The name of this enumerator.
   /// \param info Information about this enumerator.
-  void addEnumConstant(StringRef name, const EnumConstantInfo &info);
+  void addEnumConstant(StringRef name, const EnumConstantInfo &info,
+                       VersionTuple swiftVersion);
 
   /// Add information about a tag (struct/union/enum/C++ class).
   ///
   /// \param name The name of this tag.
   /// \param info Information about this tag.
-  void addTag(StringRef name, const TagInfo &info);
+  void addTag(StringRef name, const TagInfo &info,
+              VersionTuple swiftVersion);
 
   /// Add information about a typedef.
   ///
   /// \param name The name of this typedef.
   /// \param info Information about this typedef.
-  void addTypedef(StringRef name, const TypedefInfo &info);
+  void addTypedef(StringRef name, const TypedefInfo &info,
+                  VersionTuple swiftVersion);
 
   /// Add module options
   void addModuleOptions(ModuleOptions opts);

--- a/include/clang/Basic/VersionTuple.h
+++ b/include/clang/Basic/VersionTuple.h
@@ -17,6 +17,7 @@
 
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/Optional.h"
+#include "llvm/ADT/DenseMapInfo.h"
 #include <string>
 #include <tuple>
 
@@ -69,6 +70,9 @@ public:
   bool empty() const {
     return Major == 0 && Minor == 0 && Subminor == 0 && Build == 0;
   }
+
+  /// Whether this is a non-empty version tuple.
+  explicit operator bool () const { return !empty(); }
 
   /// \brief Retrieve the major version number.
   unsigned getMajor() const { return Major; }
@@ -165,4 +169,35 @@ public:
 raw_ostream& operator<<(raw_ostream &Out, const VersionTuple &V);
 
 } // end namespace clang
+
+namespace llvm {
+  // Provide DenseMapInfo for version tuples.
+  template<>
+  struct DenseMapInfo<clang::VersionTuple> {
+    static inline clang::VersionTuple getEmptyKey() {
+      return clang::VersionTuple(0x7FFFFFFF);
+    }
+    static inline clang::VersionTuple getTombstoneKey() {
+      return clang::VersionTuple(0x7FFFFFFE);
+    }
+    static unsigned getHashValue(const clang::VersionTuple& value) {
+      unsigned result = value.getMajor();
+      if (auto minor = value.getMinor())
+        result = combineHashValue(result, *minor);
+      if (auto subminor = value.getSubminor())
+        result = combineHashValue(result, *subminor);
+      if (auto build = value.getBuild())
+        result = combineHashValue(result, *build);
+
+      return result;
+    }
+
+    static bool isEqual(const clang::VersionTuple &lhs,
+                        const clang::VersionTuple &rhs) {
+      return lhs == rhs;
+    }
+  };
+
+} // end namespace llvm
+
 #endif // LLVM_CLANG_BASIC_VERSIONTUPLE_H

--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -551,6 +551,9 @@ def fno_apinotes_modules : Flag<["-"], "fno-apinotes-modules">, Group<f_clang_Gr
 def fapinotes_cache_path : Joined<["-"], "fapinotes-cache-path=">,
   Group<i_Group>, Flags<[DriverOption, CC1Option]>, MetaVarName<"<directory>">,
   HelpText<"Specify the API notes cache path">;
+def fapinotes_swift_version : Joined<["-"], "fapinotes-swift-version=">,
+  Group<f_clang_Group>, Flags<[CC1Option]>, MetaVarName<"<version>">,
+  HelpText<"Specify the Swift version to use when filtering API notes">;
 
 def fblocks : Flag<["-"], "fblocks">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Enable the 'blocks' language feature">;

--- a/lib/APINotes/APINotesFormat.h
+++ b/lib/APINotes/APINotesFormat.h
@@ -36,7 +36,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// API notes file minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t VERSION_MINOR = 15;  // source file info
+const uint16_t VERSION_MINOR = 16;  // versioned API notes.
 
 using IdentifierID = PointerEmbeddedInt<unsigned, 31>;
 using IdentifierIDField = BCVBR<16>;
@@ -60,8 +60,8 @@ enum BlockID {
   /// The identifier data block, which maps identifier strings to IDs.
   IDENTIFIER_BLOCK_ID,
 
-  /// The Objective-C class data block, which maps Objective-C class
-  /// names to information about the class.
+  /// The Objective-C context data block, which contains information about
+  /// Objective-C classes and protocols.
   OBJC_CONTEXT_BLOCK_ID,
 
   /// The Objective-C property data block, which maps Objective-C
@@ -147,13 +147,20 @@ namespace identifier_block {
 
 namespace objc_context_block {
   enum {
-    OBJC_CONTEXT_DATA = 1,
+    OBJC_CONTEXT_ID_DATA = 1,
+    OBJC_CONTEXT_INFO_DATA = 2,
   };
 
-  using ObjCContextDataLayout = BCRecordLayout<
-    OBJC_CONTEXT_DATA,  // record ID
+  using ObjCContextIDLayout = BCRecordLayout<
+    OBJC_CONTEXT_ID_DATA,  // record ID
     BCVBR<16>,  // table offset within the blob (see below)
-    BCBlob  // map from ObjC class names (as IDs) to ObjC class information
+    BCBlob  // map from ObjC class names/protocol (as IDs) to context IDs
+  >;
+
+  using ObjCContextInfoLayout = BCRecordLayout<
+    OBJC_CONTEXT_INFO_DATA,  // record ID
+    BCVBR<16>,  // table offset within the blob (see below)
+    BCBlob      // map from ObjC context IDs to context information.
   >;
 }
 

--- a/lib/APINotes/APINotesManager.cpp
+++ b/lib/APINotes/APINotesManager.cpp
@@ -153,7 +153,7 @@ APINotesManager::loadAPINotes(const FileEntry *apiNotesFile) {
     if (!buffer) return nullptr;
 
     // Load the binary form.
-    return APINotesReader::getUnmanaged(buffer);
+    return APINotesReader::getUnmanaged(buffer, SwiftVersion);
   }
 
   // If we haven't pruned the API notes cache yet during this execution, do
@@ -184,7 +184,8 @@ APINotesManager::loadAPINotes(const FileEntry *apiNotesFile) {
     // Load the file contents.
     if (auto buffer = fileMgr.getBufferForFile(compiledFile)) {
       // Load the file.
-      if (auto reader = APINotesReader::get(std::move(buffer.get()))) {
+      if (auto reader = APINotesReader::get(std::move(buffer.get()),
+                                            SwiftVersion)) {
         bool outOfDate = false;
         if (auto sizeAndModTime = reader->getSourceFileSizeAndModTime()) {
           if (sizeAndModTime->first != apiNotesFile->getSize() ||
@@ -272,7 +273,7 @@ APINotesManager::loadAPINotes(const FileEntry *apiNotesFile) {
   }
 
   // Load the binary form we just compiled.
-  auto reader = APINotesReader::get(std::move(compiledBuffer));
+  auto reader = APINotesReader::get(std::move(compiledBuffer), SwiftVersion);
   assert(reader && "Could not load the API notes we just generated?");
   return reader;
 }

--- a/lib/APINotes/APINotesManager.cpp
+++ b/lib/APINotes/APINotesManager.cpp
@@ -396,14 +396,20 @@ bool APINotesManager::loadCurrentModuleAPINotes(
     };
 
     if (module->IsFramework) {
-      // For frameworks, we search in the "APINotes" subdirectory.
+      // For frameworks, we search in the "Headers" or "PrivateHeaders"
+      // subdirectory.
       llvm::SmallString<128> path;
       path += module->Directory->getName();
-      llvm::sys::path::append(path, "APINotes");
-      if (auto apinotesDir = fileMgr.getDirectory(path)) {
+      unsigned pathLen = path.size();
+
+      llvm::sys::path::append(path, "Headers");
+      if (auto apinotesDir = fileMgr.getDirectory(path))
         tryAPINotes(apinotesDir, /*wantPublic=*/true);
-        tryAPINotes(apinotesDir, /*wantPublic=*/false);
-      }
+
+      path.resize(pathLen);
+      llvm::sys::path::append(path, "PrivateHeaders");
+      if (auto privateAPINotesDir = fileMgr.getDirectory(path))
+        tryAPINotes(privateAPINotesDir, /*wantPublic=*/false);
     } else {
       tryAPINotes(module->Directory, /*wantPublic=*/true);
       tryAPINotes(module->Directory, /*wantPublic=*/false);

--- a/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -14,6 +14,7 @@
 #include "clang/APINotes/APINotesReader.h"
 #include "clang/APINotes/Types.h"
 #include "clang/APINotes/APINotesWriter.h"
+#include "clang/Basic/VersionTuple.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/SourceMgr.h"
@@ -262,9 +263,7 @@ namespace {
   };
   typedef std::vector<Typedef> TypedefsSeq;
 
-  struct Module {
-    StringRef Name;
-    AvailabilityItem Availability;
+  struct TopLevelItems {
     ClassesSeq Classes;
     ClassesSeq Protocols;
     FunctionsSeq Functions;
@@ -272,6 +271,20 @@ namespace {
     EnumConstantsSeq EnumConstants;
     TagsSeq Tags;
     TypedefsSeq Typedefs;
+  };
+
+  struct Versioned {
+    VersionTuple Version;
+    TopLevelItems Items;
+  };
+
+  typedef std::vector<Versioned> VersionedSeq;
+
+  struct Module {
+    StringRef Name;
+    AvailabilityItem Availability;
+    TopLevelItems TopLevel;
+    VersionedSeq SwiftVersions;
 
     llvm::Optional<bool> SwiftInferImportAsMember = {llvm::None};
 
@@ -291,6 +304,7 @@ LLVM_YAML_IS_SEQUENCE_VECTOR(GlobalVariable)
 LLVM_YAML_IS_SEQUENCE_VECTOR(EnumConstant)
 LLVM_YAML_IS_SEQUENCE_VECTOR(Tag)
 LLVM_YAML_IS_SEQUENCE_VECTOR(Typedef)
+LLVM_YAML_IS_SEQUENCE_VECTOR(Versioned)
 
 namespace llvm {
   namespace yaml {
@@ -333,6 +347,24 @@ namespace llvm {
         io.enumCase(value, "nonswift",  APIAvailability::NonSwift);
         io.enumCase(value, "available", APIAvailability::Available);
       }
+    };
+
+    template <>
+    struct ScalarTraits<VersionTuple> {
+      static void output(const VersionTuple &value, void*,
+                         llvm::raw_ostream &out) {
+        out << value;
+      }
+      static StringRef input(StringRef scalar, void*, VersionTuple &value) {
+        if (value.tryParse(scalar))
+          return "not a version number in the form XX.YY";
+
+        // Canonicalize on '.' as a separator.
+        value.UseDotAsSeparator();
+        return StringRef();
+      }
+
+      static bool mustQuote(StringRef) { return false; }
     };
 
     template <>
@@ -460,6 +492,24 @@ namespace llvm {
       }
     };
 
+    static void mapTopLevelItems(IO &io, TopLevelItems &i) {
+      io.mapOptional("Classes",         i.Classes);
+      io.mapOptional("Protocols",       i.Protocols);
+      io.mapOptional("Functions",       i.Functions);
+      io.mapOptional("Globals",         i.Globals);
+      io.mapOptional("Enumerators",     i.EnumConstants);
+      io.mapOptional("Tags",            i.Tags);
+      io.mapOptional("Typedefs",        i.Typedefs);
+    }
+
+    template <>
+    struct MappingTraits<Versioned> {
+      static void mapping(IO &io, Versioned& v) {
+        io.mapRequired("Version", v.Version);
+        mapTopLevelItems(io, v.Items);
+      }
+    };
+
     template <>
     struct MappingTraits<Module> {
       static void mapping(IO &io, Module& m) {
@@ -467,13 +517,10 @@ namespace llvm {
         io.mapOptional("Availability",    m.Availability.Mode);
         io.mapOptional("AvailabilityMsg", m.Availability.Msg);
         io.mapOptional("SwiftInferImportAsMember", m.SwiftInferImportAsMember);
-        io.mapOptional("Classes",         m.Classes);
-        io.mapOptional("Protocols",       m.Protocols);
-        io.mapOptional("Functions",       m.Functions);
-        io.mapOptional("Globals",         m.Globals);
-        io.mapOptional("Enumerators",     m.EnumConstants);
-        io.mapOptional("Tags",            m.Tags);
-        io.mapOptional("Typedefs",        m.Typedefs);
+
+        mapTopLevelItems(io, m.TopLevel);
+
+        io.mapOptional("SwiftVersions",  m.SwiftVersions);
       }
     };
   }
@@ -624,7 +671,8 @@ namespace {
 
     // Translate from Method into ObjCMethodInfo and write it out.
     void convertMethod(const Method &meth,
-                       ContextID classID, StringRef className) {
+                       ContextID classID, StringRef className,
+                       VersionTuple swiftVersion) {
       ObjCMethodInfo mInfo;
 
       if (convertCommon(meth, mInfo, meth.Selector))
@@ -662,10 +710,11 @@ namespace {
       // Write it.
       Writer->addObjCMethod(classID, selectorRef,
                             meth.Kind == MethodKind::Instance,
-                            mInfo);
+                            mInfo, swiftVersion);
     }
 
-    void convertContext(const Class &cl, bool isClass) {
+    void convertContext(const Class &cl, bool isClass,
+                        VersionTuple swiftVersion) {
       // Write the class.
       ObjCContextInfo cInfo;
 
@@ -675,8 +724,8 @@ namespace {
       if (cl.AuditedForNullability)
         cInfo.setDefaultNullability(*DefaultNullability);
 
-      ContextID clID = isClass ? Writer->addObjCClass(cl.Name, cInfo) :
-                                 Writer->addObjCProtocol(cl.Name, cInfo);
+      ContextID clID = Writer->addObjCContext(cl.Name, isClass, cInfo,
+                                              swiftVersion);
 
       // Write all methods.
       llvm::StringMap<std::pair<bool, bool>> knownMethods;
@@ -693,7 +742,7 @@ namespace {
         }
         known = true;
 
-        convertMethod(method, clID, cl.Name);
+        convertMethod(method, clID, cl.Name, swiftVersion);
       }
 
       // Write all properties.
@@ -726,51 +775,45 @@ namespace {
           pInfo.setNullabilityAudited(*prop.Nullability);
         if (prop.Kind) {
           Writer->addObjCProperty(clID, prop.Name,
-                                  *prop.Kind == MethodKind::Instance, pInfo);
+                                  *prop.Kind == MethodKind::Instance, pInfo,
+                                  swiftVersion);
         } else {
           // Add both instance and class properties with this name.
-          Writer->addObjCProperty(clID, prop.Name, true, pInfo);
-          Writer->addObjCProperty(clID, prop.Name, false, pInfo);
+          Writer->addObjCProperty(clID, prop.Name, true, pInfo, swiftVersion);
+          Writer->addObjCProperty(clID, prop.Name, false, pInfo, swiftVersion);
         }
       }
     }
 
-    bool convertModule() {
-      if (!isAvailable(TheModule.Availability))
-        return false;
-
-      // Set up the writer.
-      // FIXME: This is kindof ugly.
-      APINotesWriter writer(TheModule.Name, SourceFile);
-      Writer = &writer;
-
+    void convertTopLevelItems(const TopLevelItems &items,
+                              VersionTuple swiftVersion) {
       // Write all classes.
       llvm::StringSet<> knownClasses;
-      for (const auto &cl : TheModule.Classes) {
+      for (const auto &cl : items.Classes) {
         // Check for duplicate class definitions.
         if (!knownClasses.insert(cl.Name).second) {
           emitError("multiple definitions of class '" + cl.Name + "'");
           continue;
         }
 
-        convertContext(cl, /*isClass*/ true);
+        convertContext(cl, /*isClass*/ true, swiftVersion);
       }
 
       // Write all protocols.
       llvm::StringSet<> knownProtocols;
-      for (const auto &pr : TheModule.Protocols) {
+      for (const auto &pr : items.Protocols) {
         // Check for duplicate protocol definitions.
         if (!knownProtocols.insert(pr.Name).second) {
           emitError("multiple definitions of protocol '" + pr.Name + "'");
           continue;
         }
 
-        convertContext(pr, /*isClass*/ false);
+        convertContext(pr, /*isClass*/ false, swiftVersion);
       }
 
       // Write all global variables.
       llvm::StringSet<> knownGlobals;
-      for (const auto &global : TheModule.Globals) {
+      for (const auto &global : items.Globals) {
         // Check for duplicate global variables.
         if (!knownGlobals.insert(global.Name).second) {
           emitError("multiple definitions of global variable '" +
@@ -786,12 +829,12 @@ namespace {
         info.SwiftName = global.SwiftName;
         if (global.Nullability)
           info.setNullabilityAudited(*global.Nullability);
-        Writer->addGlobalVariable(global.Name, info);
+        Writer->addGlobalVariable(global.Name, info, swiftVersion);
       }
 
       // Write all global functions.
       llvm::StringSet<> knownFunctions;
-      for (const auto &function : TheModule.Functions) {
+      for (const auto &function : items.Functions) {
         // Check for duplicate global functions.
         if (!knownFunctions.insert(function.Name).second) {
           emitError("multiple definitions of global function '" +
@@ -810,12 +853,12 @@ namespace {
                            function.NullabilityOfRet,
                            info, function.Name);
 
-        Writer->addGlobalFunction(function.Name, info);
+        Writer->addGlobalFunction(function.Name, info, swiftVersion);
       }
 
       // Write all enumerators.
       llvm::StringSet<> knownEnumConstants;
-      for (const auto &enumConstant : TheModule.EnumConstants) {
+      for (const auto &enumConstant : items.EnumConstants) {
         // Check for duplicate enumerators
         if (!knownEnumConstants.insert(enumConstant.Name).second) {
           emitError("multiple definitions of enumerator '" +
@@ -829,12 +872,12 @@ namespace {
         convertAvailability(enumConstant.Availability, info, enumConstant.Name);
         info.SwiftPrivate = enumConstant.SwiftPrivate;
         info.SwiftName = enumConstant.SwiftName;
-        Writer->addEnumConstant(enumConstant.Name, info);
+        Writer->addEnumConstant(enumConstant.Name, info, swiftVersion);
       }
 
       // Write all tags.
       llvm::StringSet<> knownTags;
-      for (const auto &t : TheModule.Tags) {
+      for (const auto &t : items.Tags) {
         // Check for duplicate tag definitions.
         if (!knownTags.insert(t.Name).second) {
           emitError("multiple definitions Of tag '" + t.Name + "'");
@@ -845,12 +888,12 @@ namespace {
         if (convertCommonType(t, tagInfo, t.Name))
           continue;
 
-        Writer->addTag(t.Name, tagInfo);
+        Writer->addTag(t.Name, tagInfo, swiftVersion);
       }
 
       // Write all typedefs.
       llvm::StringSet<> knownTypedefs;
-      for (const auto &t : TheModule.Typedefs) {
+      for (const auto &t : items.Typedefs) {
         // Check for duplicate typedef definitions.
         if (!knownTypedefs.insert(t.Name).second) {
           emitError("multiple definitions of typedef '" + t.Name + "'");
@@ -860,14 +903,33 @@ namespace {
         TypedefInfo typedefInfo;
         if (convertCommonType(t, typedefInfo, t.Name))
           continue;
-
-        Writer->addTypedef(t.Name, typedefInfo);
+        
+        Writer->addTypedef(t.Name, typedefInfo, swiftVersion);
       }
+    }
+
+    bool convertModule() {
+      if (!isAvailable(TheModule.Availability))
+        return false;
+
+      // Set up the writer.
+      // FIXME: This is kindof ugly.
+      APINotesWriter writer(TheModule.Name, SourceFile);
+      Writer = &writer;
+
+      // Write the top-level items.
+      convertTopLevelItems(TheModule.TopLevel, VersionTuple());
 
       if (TheModule.SwiftInferImportAsMember) {
         ModuleOptions opts;
         opts.SwiftInferImportAsMember = true;
         Writer->addModuleOptions(opts);
+      }
+
+      // Convert the versioned information.
+      for (const auto &versioned : TheModule.SwiftVersions) {
+        convertTopLevelItems(versioned.Items, versioned.Version);
+
       }
 
       if (!ErrorOccured)
@@ -934,10 +996,34 @@ namespace {
     /// The module we're building.
     Module TheModule;
 
+    /// A known context, which tracks what we know about a context ID.
+    struct KnownContext {
+      /// Whether this is a protocol (vs. a class).
+      bool isProtocol;
+
+      /// The indices into the top-level items for this context at each
+      /// Swift version.
+      SmallVector<std::pair<VersionTuple, unsigned>, 1> indices;
+
+      Class &getContext(const VersionTuple &swiftVersion,
+                        TopLevelItems &items) {
+        ClassesSeq &seq = isProtocol ? items.Protocols : items.Classes;
+
+        for (auto &index : indices) {
+          if (index.first == swiftVersion)
+            return seq[index.second];
+        }
+
+        indices.push_back({swiftVersion, seq.size()});
+        seq.push_back(Class());
+        return seq.back();
+      }
+    };
+
     /// A mapping from context ID to a pair (index, is-protocol) that indicates
     /// the index of that class or protocol in the global "classes" or
     /// "protocols" list.
-    llvm::DenseMap<unsigned, std::pair<unsigned, bool>> knownContexts;
+    llvm::DenseMap<unsigned, KnownContext> knownContexts;
 
     /// Copy a string into allocated memory so it does disappear on us.
     StringRef copyString(StringRef string) {
@@ -1015,30 +1101,46 @@ namespace {
       }
     }
 
+    TopLevelItems &getTopLevelItems(VersionTuple swiftVersion) {
+      if (!swiftVersion) return TheModule.TopLevel;
+
+      for (auto &versioned : TheModule.SwiftVersions) {
+        if (versioned.Version == swiftVersion)
+          return versioned.Items;
+      }
+
+      TheModule.SwiftVersions.push_back(Versioned());
+      TheModule.SwiftVersions.back().Version = swiftVersion;
+      return TheModule.SwiftVersions.back().Items;
+    }
+
   public:
     virtual void visitObjCClass(ContextID contextID, StringRef name,
-                                const ObjCContextInfo &info) {
+                                const ObjCContextInfo &info,
+                                VersionTuple swiftVersion) {
       // Record this known context.
-      knownContexts[contextID.Value] = { TheModule.Classes.size(), false };
+      auto &items = getTopLevelItems(swiftVersion);
+      auto &known = knownContexts[contextID.Value];
+      known.isProtocol = false;
 
-      // Add the class.
-      TheModule.Classes.push_back(Class());
-      handleObjCContext(TheModule.Classes.back(), name, info);
+      handleObjCContext(known.getContext(swiftVersion, items), name, info);
     }
 
     virtual void visitObjCProtocol(ContextID contextID, StringRef name,
-                                   const ObjCContextInfo &info) {
+                                   const ObjCContextInfo &info,
+                                   VersionTuple swiftVersion) {
       // Record this known context.
-      knownContexts[contextID.Value] = { TheModule.Protocols.size(), true };
+      auto &items = getTopLevelItems(swiftVersion);
+      auto &known = knownContexts[contextID.Value];
+      known.isProtocol = true;
 
-      // Add the protocol.
-      TheModule.Protocols.push_back(Class());
-      handleObjCContext(TheModule.Protocols.back(), name, info);
+      handleObjCContext(known.getContext(swiftVersion, items), name, info);
     }
 
     virtual void visitObjCMethod(ContextID contextID, StringRef selector,
                                  bool isInstanceMethod,
-                                 const ObjCMethodInfo &info) {
+                                 const ObjCMethodInfo &info,
+                                 VersionTuple swiftVersion) {
       Method method;
       method.Selector = copyString(selector);
       method.Kind = isInstanceMethod ? MethodKind::Instance : MethodKind::Class;
@@ -1051,16 +1153,15 @@ namespace {
       method.DesignatedInit = info.DesignatedInit;
       method.Required = info.Required;
 
-      auto known = knownContexts[contextID.Value];
-      if (known.second)
-        TheModule.Protocols[known.first].Methods.push_back(method);
-      else
-        TheModule.Classes[known.first].Methods.push_back(method);
+      auto &items = getTopLevelItems(swiftVersion);
+      knownContexts[contextID.Value].getContext(swiftVersion, items)
+        .Methods.push_back(method);
     }
 
     virtual void visitObjCProperty(ContextID contextID, StringRef name,
                                    bool isInstance,
-                                   const ObjCPropertyInfo &info) {
+                                   const ObjCPropertyInfo &info,
+                                   VersionTuple swiftVersion) {
       Property property;
       property.Name = name;
       property.Kind = isInstance ? MethodKind::Instance : MethodKind::Class;
@@ -1071,15 +1172,14 @@ namespace {
         property.Nullability = *nullability;
       }
 
-      auto known = knownContexts[contextID.Value];
-      if (known.second)
-        TheModule.Protocols[known.first].Properties.push_back(property);
-      else
-        TheModule.Classes[known.first].Properties.push_back(property);
+      auto &items = getTopLevelItems(swiftVersion);
+      knownContexts[contextID.Value].getContext(swiftVersion, items)
+        .Properties.push_back(property);
     }
 
     virtual void visitGlobalFunction(StringRef name,
-                                     const GlobalFunctionInfo &info) {
+                                     const GlobalFunctionInfo &info,
+                                     VersionTuple swiftVersion) {
       Function function;
       function.Name = name;
       handleCommon(function, info);
@@ -1088,11 +1188,13 @@ namespace {
         handleNullability(function.Nullability, function.NullabilityOfRet,
                           info, info.NumAdjustedNullable-1);
 
-      TheModule.Functions.push_back(function);
+      auto &items = getTopLevelItems(swiftVersion);
+      items.Functions.push_back(function);
     }
 
     virtual void visitGlobalVariable(StringRef name,
-                                     const GlobalVariableInfo &info) {
+                                     const GlobalVariableInfo &info,
+                                     VersionTuple swiftVersion) {
       GlobalVariable global;
       global.Name = name;
       handleCommon(global, info);
@@ -1102,30 +1204,37 @@ namespace {
         global.Nullability = *nullability;
       }
 
-      TheModule.Globals.push_back(global);
+      auto &items = getTopLevelItems(swiftVersion);
+      items.Globals.push_back(global);
     }
 
     virtual void visitEnumConstant(StringRef name,
-                                   const EnumConstantInfo &info) {
+                                   const EnumConstantInfo &info,
+                                   VersionTuple swiftVersion) {
       EnumConstant enumConstant;
       enumConstant.Name = name;
       handleCommon(enumConstant, info);
 
-      TheModule.EnumConstants.push_back(enumConstant);
+      auto &items = getTopLevelItems(swiftVersion);
+      items.EnumConstants.push_back(enumConstant);
     }
 
-    virtual void visitTag(StringRef name, const TagInfo &info) {
+    virtual void visitTag(StringRef name, const TagInfo &info,
+                          VersionTuple swiftVersion) {
       Tag tag;
       tag.Name = name;
       handleCommonType(tag, info);
-      TheModule.Tags.push_back(tag);
+      auto &items = getTopLevelItems(swiftVersion);
+      items.Tags.push_back(tag);
     }
 
-    virtual void visitTypedef(StringRef name, const TypedefInfo &info) {
+    virtual void visitTypedef(StringRef name, const TypedefInfo &info,
+                              VersionTuple swiftVersion) {
       Typedef td;
       td.Name = name;
       handleCommonType(td, info);
-      TheModule.Typedefs.push_back(td);
+      auto &items = getTopLevelItems(swiftVersion);
+      items.Typedefs.push_back(td);
     }
 
     /// Retrieve the module.
@@ -1136,6 +1245,74 @@ namespace {
 /// Produce a flattened, numeric value for optional method/property kinds.
 static unsigned flattenPropertyKind(llvm::Optional<MethodKind> kind) {
   return kind ? (*kind == MethodKind::Instance ? 2 : 1) : 0;
+}
+
+/// Sort the items in the given block of "top-level" items.
+static void sortTopLevelItems(TopLevelItems &items) {
+  // Sort classes.
+  std::sort(items.Classes.begin(), items.Classes.end(),
+            [](const Class &lhs, const Class &rhs) -> bool {
+              return lhs.Name < rhs.Name;
+            });
+
+  // Sort protocols.
+  std::sort(items.Protocols.begin(), items.Protocols.end(),
+            [](const Class &lhs, const Class &rhs) -> bool {
+              return lhs.Name < rhs.Name;
+            });
+
+  // Sort methods and properties within each class and protocol.
+  auto sortMembers = [](Class &record) {
+    // Sort properties.
+    std::sort(record.Properties.begin(), record.Properties.end(),
+              [](const Property &lhs, const Property &rhs) -> bool {
+                return lhs.Name < rhs.Name ||
+                (lhs.Name == rhs.Name &&
+                 flattenPropertyKind(lhs.Kind) <
+                 flattenPropertyKind(rhs.Kind));
+              });
+
+    // Sort methods.
+    std::sort(record.Methods.begin(), record.Methods.end(),
+              [](const Method &lhs, const Method &rhs) -> bool {
+                return lhs.Selector < rhs.Selector ||
+                (lhs.Selector == rhs.Selector &&
+                 static_cast<unsigned>(lhs.Kind)
+                 < static_cast<unsigned>(rhs.Kind));
+              });
+  };
+  std::for_each(items.Classes.begin(), items.Classes.end(), sortMembers);
+  std::for_each(items.Protocols.begin(), items.Protocols.end(), sortMembers);
+
+  // Sort functions.
+  std::sort(items.Functions.begin(), items.Functions.end(),
+            [](const Function &lhs, const Function &rhs) -> bool {
+              return lhs.Name < rhs.Name;
+            });
+
+  // Sort global variables.
+  std::sort(items.Globals.begin(), items.Globals.end(),
+            [](const GlobalVariable &lhs, const GlobalVariable &rhs) -> bool {
+              return lhs.Name < rhs.Name;
+            });
+
+  // Sort enum constants.
+  std::sort(items.EnumConstants.begin(), items.EnumConstants.end(),
+            [](const EnumConstant &lhs, const EnumConstant &rhs) -> bool {
+              return lhs.Name < rhs.Name;
+            });
+
+  // Sort tags.
+  std::sort(items.Tags.begin(), items.Tags.end(),
+            [](const Tag &lhs, const Tag &rhs) -> bool {
+              return lhs.Name < rhs.Name;
+            });
+
+  // Sort typedefs.
+  std::sort(items.Typedefs.begin(), items.Typedefs.end(),
+            [](const Typedef &lhs, const Typedef &rhs) -> bool {
+              return lhs.Name < rhs.Name;
+            });
 }
 
 bool api_notes::decompileAPINotes(std::unique_ptr<llvm::MemoryBuffer> input,
@@ -1162,70 +1339,18 @@ bool api_notes::decompileAPINotes(std::unique_ptr<llvm::MemoryBuffer> input,
   if (opts.SwiftInferImportAsMember)
     module.SwiftInferImportAsMember = true;
 
-  // Sort classes.
-  std::sort(module.Classes.begin(), module.Classes.end(),
-            [](const Class &lhs, const Class &rhs) -> bool {
-              return lhs.Name < rhs.Name;
+  // Sort the top-level items.
+  sortTopLevelItems(module.TopLevel);
+
+  // Sort the Swift versions.
+  std::sort(module.SwiftVersions.begin(), module.SwiftVersions.end(),
+            [](const Versioned &lhs, const Versioned &rhs) -> bool {
+              return lhs.Version < rhs.Version;
             });
 
-  // Sort protocols.
-  std::sort(module.Protocols.begin(), module.Protocols.end(),
-            [](const Class &lhs, const Class &rhs) -> bool {
-              return lhs.Name < rhs.Name;
-            });
-
-  // Sort methods and properties within each class and protocol.
-  auto sortMembers = [](Class &record) {
-    // Sort properties.
-    std::sort(record.Properties.begin(), record.Properties.end(),
-              [](const Property &lhs, const Property &rhs) -> bool {
-                return lhs.Name < rhs.Name ||
-                  (lhs.Name == rhs.Name &&
-                   flattenPropertyKind(lhs.Kind) < 
-                     flattenPropertyKind(rhs.Kind));
-              });
-
-    // Sort methods.
-    std::sort(record.Methods.begin(), record.Methods.end(),
-              [](const Method &lhs, const Method &rhs) -> bool {
-                return lhs.Selector < rhs.Selector ||
-                       (lhs.Selector == rhs.Selector &&
-                        static_cast<unsigned>(lhs.Kind)
-                          < static_cast<unsigned>(rhs.Kind));
-              });
-  };
-  std::for_each(module.Classes.begin(), module.Classes.end(), sortMembers);
-  std::for_each(module.Protocols.begin(), module.Protocols.end(), sortMembers);
-
-  // Sort functions.
-  std::sort(module.Functions.begin(), module.Functions.end(),
-            [](const Function &lhs, const Function &rhs) -> bool {
-              return lhs.Name < rhs.Name;
-            });
-
-  // Sort global variables.
-  std::sort(module.Globals.begin(), module.Globals.end(),
-            [](const GlobalVariable &lhs, const GlobalVariable &rhs) -> bool {
-              return lhs.Name < rhs.Name;
-            });
-
-  // Sort enum constants.
-  std::sort(module.EnumConstants.begin(), module.EnumConstants.end(),
-            [](const EnumConstant &lhs, const EnumConstant &rhs) -> bool {
-              return lhs.Name < rhs.Name;
-            });
-
-  // Sort tags.
-  std::sort(module.Tags.begin(), module.Tags.end(),
-            [](const Tag &lhs, const Tag &rhs) -> bool {
-              return lhs.Name < rhs.Name;
-            });
-
-  // Sort typedefs.
-  std::sort(module.Typedefs.begin(), module.Typedefs.end(),
-            [](const Typedef &lhs, const Typedef &rhs) -> bool {
-              return lhs.Name < rhs.Name;
-            });
+  // Sort the top-level items within each Swift version.
+  for (auto &versioned : module.SwiftVersions)
+    sortTopLevelItems(versioned.Items);
 
   // Output the YAML representation.
   Output yout(os);

--- a/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -1318,7 +1318,7 @@ static void sortTopLevelItems(TopLevelItems &items) {
 bool api_notes::decompileAPINotes(std::unique_ptr<llvm::MemoryBuffer> input,
                                   llvm::raw_ostream &os) {
   // Try to read the file.
-  auto reader = APINotesReader::get(std::move(input));
+  auto reader = APINotesReader::get(std::move(input), VersionTuple());
   if (!reader) {
     llvm::errs() << "not a well-formed API notes binary file\n";
     return true;

--- a/lib/Frontend/CompilerInstance.cpp
+++ b/lib/Frontend/CompilerInstance.cpp
@@ -540,6 +540,9 @@ void CompilerInstance::createSema(TranslationUnitKind TUKind,
   TheSema.reset(new Sema(getPreprocessor(), getASTContext(), getASTConsumer(),
                          TUKind, CompletionConsumer));
 
+  // Set up API notes.
+  TheSema->APINotes.setSwiftVersion(getAPINotesOpts().SwiftVersion);
+
   // If we're building a module and are supposed to load API notes,
   // notify the API notes manager.
   if (auto currentModule = getPreprocessor().getCurrentModule()) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2502,7 +2502,9 @@ std::string CompilerInvocation::getModuleHash() const {
   // Extend the signature with the module file extensions.
   const FrontendOptions &frontendOpts = getFrontendOpts();
   for (const auto &ext : frontendOpts.ModuleFileExtensions) {
-    code = ext->hashExtension(code);
+    code = hash_combine(code, ext->hashExtension(code));
+  }
+
   }
 
   // Darwin-specific hack: if we have a sysroot, use the contents and

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1473,8 +1473,14 @@ static void ParseHeaderSearchArgs(HeaderSearchOptions &Opts, ArgList &Args) {
     Opts.AddVFSOverlayFile(A->getValue());
 }
 
-static void ParseAPINotesArgs(APINotesOptions &Opts, ArgList &Args) {
+static void ParseAPINotesArgs(APINotesOptions &Opts, ArgList &Args,
+                              DiagnosticsEngine &diags) {
   using namespace options;
+  if (const Arg *A = Args.getLastArg(OPT_fapinotes_swift_version)) {
+    if (Opts.SwiftVersion.tryParse(A->getValue()))
+      diags.Report(diag::err_drv_invalid_value)
+        << A->getAsString(Args) << A->getValue();
+  }
   for (const Arg *A : Args.filtered(OPT_iapinotes_modules))
     Opts.ModuleSearchPaths.push_back(A->getValue());
 }
@@ -2369,7 +2375,7 @@ bool CompilerInvocation::CreateFromArgs(CompilerInvocation &Res,
   Success &= ParseCodeGenArgs(Res.getCodeGenOpts(), Args, DashX, Diags,
                               Res.getTargetOpts());
   ParseHeaderSearchArgs(Res.getHeaderSearchOpts(), Args);
-  ParseAPINotesArgs(Res.getAPINotesOpts(), Args);
+  ParseAPINotesArgs(Res.getAPINotesOpts(), Args, Diags);
 
   if (DashX == IK_AST || DashX == IK_LLVM_IR) {
     // ObjCAAutoRefCount and Sanitize LangOpts are used to setup the
@@ -2505,6 +2511,16 @@ std::string CompilerInvocation::getModuleHash() const {
     code = hash_combine(code, ext->hashExtension(code));
   }
 
+  // Extend the signature with the SWift version for API notes.
+  const APINotesOptions &apiNotesOpts = getAPINotesOpts();
+  if (apiNotesOpts.SwiftVersion) {
+    code = hash_combine(code, apiNotesOpts.SwiftVersion.getMajor());
+    if (auto minor = apiNotesOpts.SwiftVersion.getMinor())
+      code = hash_combine(code, *minor);
+    if (auto subminor = apiNotesOpts.SwiftVersion.getSubminor())
+      code = hash_combine(code, *subminor);
+    if (auto build = apiNotesOpts.SwiftVersion.getBuild())
+      code = hash_combine(code, *build);
   }
 
   // Darwin-specific hack: if we have a sysroot, use the contents and

--- a/lib/Sema/SemaAPINotes.cpp
+++ b/lib/Sema/SemaAPINotes.cpp
@@ -352,8 +352,8 @@ void Sema::ProcessAPINotes(Decl *D) {
     // Objective-C classes.
     if (auto Class = dyn_cast<ObjCInterfaceDecl>(D)) {
       for (auto Reader : APINotes.findAPINotes(D->getLocation())) {
-        if (auto Info = Reader->lookupObjCClass(Class->getName())) {
-          ::ProcessAPINotes(*this, Class, Info->second);
+        if (auto Info = Reader->lookupObjCClassInfo(Class->getName())) {
+          ::ProcessAPINotes(*this, Class, *Info);
         }
       }
 
@@ -363,8 +363,8 @@ void Sema::ProcessAPINotes(Decl *D) {
     // Objective-C protocols.
     if (auto Protocol = dyn_cast<ObjCProtocolDecl>(D)) {
       for (auto Reader : APINotes.findAPINotes(D->getLocation())) {
-        if (auto Info = Reader->lookupObjCProtocol(Protocol->getName())) {
-          ::ProcessAPINotes(*this, Protocol, Info->second);
+        if (auto Info = Reader->lookupObjCProtocolInfo(Protocol->getName())) {
+          ::ProcessAPINotes(*this, Protocol, *Info);
         }
       }
 
@@ -414,8 +414,8 @@ void Sema::ProcessAPINotes(Decl *D) {
     auto GetContext = [&](api_notes::APINotesReader *Reader)
                         -> Optional<api_notes::ContextID> {
       if (auto Protocol = dyn_cast<ObjCProtocolDecl>(ObjCContainer)) {
-        if (auto Found = Reader->lookupObjCProtocol(Protocol->getName()))
-          return Found->first;
+        if (auto Found = Reader->lookupObjCProtocolID(Protocol->getName()))
+          return *Found;
 
         return None;
       }
@@ -442,8 +442,8 @@ void Sema::ProcessAPINotes(Decl *D) {
       }
 
       if (auto Class = dyn_cast<ObjCInterfaceDecl>(ObjCContainer)) {
-        if (auto Found = Reader->lookupObjCClass(Class->getName()))
-          return Found->first;
+        if (auto Found = Reader->lookupObjCClassID(Class->getName()))
+          return *Found;
 
         return None;
 

--- a/test/APINotes/Inputs/Frameworks/SomeKit.framework/APINotes/SomeKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/SomeKit.framework/APINotes/SomeKit.apinotes
@@ -31,3 +31,12 @@ Classes:
       - Selector: "initWithA:"
         MethodKind: Instance
         DesignatedInit: true
+SwiftVersions:
+  - Version: 3.0
+    Classes:
+      - Name: A
+        Methods:
+          - Selector: "transform:integer:"
+            MethodKind:      Instance
+            NullabilityOfRet: O
+            Nullability:      [ O, S ]

--- a/test/APINotes/Inputs/Frameworks/SomeKit.framework/Headers/SomeKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/SomeKit.framework/Headers/SomeKit.apinotes
@@ -1,0 +1,42 @@
+Name: SomeKit
+Classes:
+  - Name: A
+    Methods:
+      - Selector:        "transform:"
+        MethodKind:      Instance
+        Availability:    none
+        AvailabilityMsg: "anything but this"
+      - Selector: "transform:integer:"
+        MethodKind:      Instance
+        NullabilityOfRet: N
+        Nullability:      [ N, S ]
+    Properties:
+      - Name: intValue
+        PropertyKind:    Instance
+        Availability: none
+        AvailabilityMsg: "wouldn't work anyway"
+      - Name: nonnullAInstance
+        PropertyKind:    Instance
+        Nullability:     N
+      - Name: nonnullAClass
+        PropertyKind:    Class
+        Nullability:     N
+      - Name: nonnullABoth
+        Nullability:     N
+  - Name: B
+    Availability: none
+    AvailabilityMsg: "just don't"
+  - Name: C
+    Methods:
+      - Selector: "initWithA:"
+        MethodKind: Instance
+        DesignatedInit: true
+SwiftVersions:
+  - Version: 3.0
+    Classes:
+      - Name: A
+        Methods:
+          - Selector: "transform:integer:"
+            MethodKind:      Instance
+            NullabilityOfRet: O
+            Nullability:      [ O, S ]

--- a/test/APINotes/Inputs/Frameworks/SomeKit.framework/Headers/SomeKitExplicitNullability.h
+++ b/test/APINotes/Inputs/Frameworks/SomeKit.framework/Headers/SomeKitExplicitNullability.h
@@ -1,0 +1,5 @@
+@interface A(ExplicitNullabilityProperties)
+@property (nonatomic, readwrite, retain, nonnull) A *explicitNonnullInstance;
+@property (nonatomic, readwrite, retain, nullable) A *explicitNullableInstance;
+@end
+

--- a/test/APINotes/Inputs/Frameworks/SomeKit.framework/PrivateHeaders/SomeKit_private.apinotes
+++ b/test/APINotes/Inputs/Frameworks/SomeKit.framework/PrivateHeaders/SomeKit_private.apinotes
@@ -1,0 +1,15 @@
+Name: SomeKit
+Classes:
+  - Name: A
+    Methods:         
+      - Selector: "privateTransform:input:"
+        MethodKind:      Instance
+        NullabilityOfRet: N
+        Nullability:      [ N, S ]
+    Properties:
+      - Name: internalProperty
+        Nullability: N
+Protocols:
+  - Name: InternalProtocol
+    Availability: none
+    AvailabilityMsg: "not for you"

--- a/test/APINotes/Inputs/Frameworks/SomeOtherKit.framework/Headers/SomeOtherKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/SomeOtherKit.framework/Headers/SomeOtherKit.apinotes
@@ -1,0 +1,8 @@
+Name: SomeOtherKit
+Classes:
+  - Name: A
+    Methods:
+      - Selector:        "methodA"
+        MethodKind:      Instance
+        Availability:    none
+        AvailabilityMsg: "anything but this"

--- a/test/APINotes/Inputs/roundtrip.apinotes
+++ b/test/APINotes/Inputs/roundtrip.apinotes
@@ -146,3 +146,22 @@ Typedefs:
     SwiftName:       Typedef
     SwiftBridge:     ''
     NSErrorDomain:   ''
+SwiftVersions:   
+  - Version:         3.0
+    Classes:         
+      - Name:            NSCell
+        Availability:    available
+        AvailabilityMsg: ''
+        SwiftPrivate:    false
+        SwiftName:       NSBox
+        SwiftBridge:     ''
+        NSErrorDomain:   ''
+        Methods:         
+          - Selector:        init
+            MethodKind:      Instance
+            NullabilityOfRet: N
+            Availability:    available
+            AvailabilityMsg: ''
+            SwiftPrivate:    true
+            SwiftName:       ''
+            DesignatedInit:  true

--- a/test/APINotes/nullability.m
+++ b/test/APINotes/nullability.m
@@ -1,12 +1,22 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -verify
 
+// Test with Swift version 3.0. This should only affect the few APIs that have an entry in the 3.0 tables.
+
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -fapinotes-swift-version=3.0 -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -verify -DSWIFT_VERSION_3_0
+
 #import <SomeKit/SomeKit.h>
 
 int main() {
   A *a;
 
-  [a transform: 0 integer: 0]; // expected-warning{{null passed to a callee that requires a non-null argument}}
+#if SWIFT_VERSION_3_0
+  float *fp =  // expected-warning{{incompatible pointer types initializing 'float *' with an expression of type 'A * _Nullable'}}
+    [a transform: 0 integer: 0];
+#else
+  float *fp =  // expected-warning{{incompatible pointer types initializing 'float *' with an expression of type 'A *'}}
+    [a transform: 0 integer: 0]; // expected-warning{{null passed to a callee that requires a non-null argument}}
+#endif
 
   [a setNonnullAInstance: 0]; // expected-warning{{null passed to a callee that requires a non-null argument}}
   [A setNonnullAInstance: 0]; // no warning


### PR DESCRIPTION
This PR extensions API notes to introduce a Swift versioning, with a command-line flag `-fapinotes-swift-version=XX.YY` to select which version of the API nodes should be applied. This is much (but not all) of rdar://problem/28455809, for which we still need the ability for versioned API notes to override information in headers. However, this is a good start.
