### PR TITLE
[API Notes] Allow versioned API notes to override information provided by headers

### DIFF
--- a/include/clang/APINotes/APINotesReader.h
+++ b/include/clang/APINotes/APINotesReader.h
@@ -25,6 +25,20 @@
 namespace clang {
 namespace api_notes {
 
+/// Describes the role of a specific bit of versioned information.
+enum class VersionedInfoRole : unsigned {
+  /// Augment the AST, but do not override information explicitly specified
+  /// in the source code.
+  AugmentSource,
+
+  /// Replace information that may have been explicitly specified in the source
+  /// code.
+  ReplaceSource,
+
+  /// Describes an alternate version of this information.
+  Versioned,
+};
+
 /// A class that reads API notes data from a binary file that was written by
 /// the \c APINotesWriter.
 class APINotesReader {
@@ -80,6 +94,9 @@ public:
     /// Swift version, or \c Results.size() if nothing matched.
     unsigned Selected;
 
+    /// The role of the selected index.
+    VersionedInfoRole SelectedRole;
+
   public:
     /// Form an empty set of versioned information.
     VersionedInfo(llvm::NoneType) : Selected(0) { }
@@ -103,6 +120,11 @@ public:
     Optional<unsigned> getSelected() const {
       if (Selected == Results.size()) return None;
       return Selected;
+    }
+
+    /// Describes the role of the selected entity.
+    VersionedInfoRole getSelectedRole() const {
+      return SelectedRole;
     }
 
     /// Return the number of versioned results we know about.

--- a/include/clang/AST/AttrIterator.h
+++ b/include/clang/AST/AttrIterator.h
@@ -108,6 +108,8 @@ public:
                          specific_attr_iterator Right) {
     return !(Left == Right);
   }
+
+  Iterator getCurrent() const { return Current; }
 };
 
 template <typename SpecificAttr, typename Container>

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -3097,11 +3097,15 @@ public:
   /// method) or an Objective-C property attribute, rather than as an
   /// underscored type specifier.
   ///
+  /// \param overrideExisting Whether to override an existing, locally-specified
+  /// nullability specifier rather than complaining about the conflict.
+  ///
   /// \returns true if nullability cannot be applied, false otherwise.
   bool checkNullabilityTypeSpecifier(QualType &type, NullabilityKind nullability,
                                      SourceLocation nullabilityLoc,
                                      bool isContextSensitive,
-                                     bool implicit);
+                                     bool implicit,
+                                     bool overrideExisting = false);
 
   /// \brief Stmt attributes - this routine is the top level dispatcher.
   StmtResult ProcessStmtAttributes(Stmt *Stmt, AttributeList *Attrs,

--- a/lib/APINotes/APINotesFormat.h
+++ b/lib/APINotes/APINotesFormat.h
@@ -36,7 +36,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// API notes file minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t VERSION_MINOR = 16;  // versioned API notes.
+const uint16_t VERSION_MINOR = 17;  // optional NSErrorDomain
 
 using IdentifierID = PointerEmbeddedInt<unsigned, 31>;
 using IdentifierIDField = BCVBR<16>;

--- a/lib/APINotes/APINotesReader.cpp
+++ b/lib/APINotes/APINotesReader.cpp
@@ -1451,9 +1451,14 @@ APINotesReader::VersionedInfo<T>::VersionedInfo(
   // Look for an exact version match.
   Optional<unsigned> unversioned;
   Selected = Results.size();
+  SelectedRole = VersionedInfoRole::Versioned;
+
   for (unsigned i = 0, n = Results.size(); i != n; ++i) {
     if (Results[i].first == version) {
       Selected = i;
+
+      if (version) SelectedRole = VersionedInfoRole::ReplaceSource;
+      else SelectedRole = VersionedInfoRole::AugmentSource;
       break;
     }
 
@@ -1465,9 +1470,11 @@ APINotesReader::VersionedInfo<T>::VersionedInfo(
 
   // If we didn't find a match but we have an unversioned result, use the
   // unversioned result.
-  if (Selected == Results.size() && unversioned)
+  if (Selected == Results.size() && unversioned) {
     Selected = *unversioned;
-}
+    SelectedRole = VersionedInfoRole::AugmentSource;
+  }
+  }
 
 auto APINotesReader::lookupObjCClassID(StringRef name) -> Optional<ContextID> {
   if (!Impl.ObjCContextIDTable)

--- a/lib/APINotes/APINotesReader.cpp
+++ b/lib/APINotes/APINotesReader.cpp
@@ -126,15 +126,19 @@ namespace {
 
     unsigned swiftBridgeLength =
         endian::readNext<uint16_t, little, unaligned>(data);
-    info.setSwiftBridge(
-        StringRef(reinterpret_cast<const char *>(data), swiftBridgeLength));
-    data += swiftBridgeLength;
+    if (swiftBridgeLength > 0) {
+      info.setSwiftBridge(
+        std::string(reinterpret_cast<const char *>(data), swiftBridgeLength-1));
+      data += swiftBridgeLength-1;
+    }
 
     unsigned errorDomainLength =
       endian::readNext<uint16_t, little, unaligned>(data);
-    info.setNSErrorDomain(
-        StringRef(reinterpret_cast<const char *>(data), errorDomainLength));
-    data += errorDomainLength;
+    if (errorDomainLength > 0) {
+      info.setNSErrorDomain(
+        std::string(reinterpret_cast<const char *>(data), errorDomainLength-1));
+      data += errorDomainLength-1;
+    }
   }
 
   /// Used to deserialize the on-disk identifier table.
@@ -303,8 +307,10 @@ namespace {
       if (payload & 0x01)
         pi.setNullabilityAudited(static_cast<NullabilityKind>(nullabilityValue));
       payload >>= 1;
-      pi.setNoEscape(payload & 0x01);
-      payload >>= 1; assert(payload == 0 && "Bad API notes");
+      if (payload & 0x01) {
+        pi.setNoEscape(payload & 0x02);
+      }
+      payload >>= 2; assert(payload == 0 && "Bad API notes");
 
       info.Params.push_back(pi);
       --numParams;

--- a/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -929,7 +929,6 @@ namespace {
       // Convert the versioned information.
       for (const auto &versioned : TheModule.SwiftVersions) {
         convertTopLevelItems(versioned.Items, versioned.Version);
-
       }
 
       if (!ErrorOccured)

--- a/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -171,7 +171,7 @@ namespace {
 
   struct Param {
     unsigned Position;
-    bool NoEscape = false;
+    Optional<bool> NoEscape = false;
     llvm::Optional<NullabilityKind> Nullability;
   };
   typedef std::vector<Param> ParamsSeq;
@@ -208,8 +208,8 @@ namespace {
     AvailabilityItem Availability;
     bool SwiftPrivate = false;
     StringRef SwiftName;
-    StringRef SwiftBridge;
-    StringRef NSErrorDomain;
+    Optional<StringRef> SwiftBridge;
+    Optional<StringRef> NSErrorDomain;
     MethodsSeq Methods;
     PropertiesSeq Properties;
   };
@@ -248,8 +248,8 @@ namespace {
     AvailabilityItem Availability;
     StringRef SwiftName;
     bool SwiftPrivate = false;
-    StringRef SwiftBridge;
-    StringRef NSErrorDomain;
+    Optional<StringRef> SwiftBridge;
+    Optional<StringRef> NSErrorDomain;
   };
   typedef std::vector<Tag> TagsSeq;
 
@@ -258,8 +258,8 @@ namespace {
     AvailabilityItem Availability;
     StringRef SwiftName;
     bool SwiftPrivate = false;
-    StringRef SwiftBridge;
-    StringRef NSErrorDomain;
+    Optional<StringRef> SwiftBridge;
+    Optional<StringRef> NSErrorDomain;
   };
   typedef std::vector<Typedef> TypedefsSeq;
 
@@ -1033,6 +1033,20 @@ namespace {
       return StringRef(reinterpret_cast<const char *>(ptr), string.size());
     }
 
+    /// Copy an optional string into allocated memory so it does disappear on us.
+    Optional<StringRef> maybeCopyString(Optional<StringRef> string) {
+      if (!string) return None;
+
+      return copyString(*string);
+    }
+
+    /// Copy an optional string into allocated memory so it does disappear on us.
+    Optional<StringRef> maybeCopyString(Optional<std::string> string) {
+      if (!string) return None;
+
+      return copyString(*string);
+    }
+
     template<typename T>
     void handleCommon(T &record, const CommonEntityInfo &info) {
       handleAvailability(record.Availability, info);
@@ -1043,8 +1057,8 @@ namespace {
     template<typename T>
     void handleCommonType(T &record, const CommonTypeInfo &info) {
       handleCommon(record, info);
-      record.SwiftBridge = copyString(info.getSwiftBridge());      
-      record.NSErrorDomain = copyString(info.getNSErrorDomain());
+      record.SwiftBridge = maybeCopyString(info.getSwiftBridge());
+      record.NSErrorDomain = maybeCopyString(info.getNSErrorDomain());
     }
 
     /// Map Objective-C context info.

--- a/lib/AST/DeclPrinter.cpp
+++ b/lib/AST/DeclPrinter.cpp
@@ -1137,6 +1137,9 @@ void DeclPrinter::VisitObjCInterfaceDecl(ObjCInterfaceDecl *OID) {
     return;
   }
   bool eolnOut = false;
+  prettyPrintAttributes(OID);
+  if (OID->hasAttrs()) Out << "\n";
+
   Out << "@interface " << I;
 
   if (auto TypeParams = OID->getTypeParamListAsWritten()) {

--- a/lib/Driver/Tools.cpp
+++ b/lib/Driver/Tools.cpp
@@ -5364,6 +5364,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     const char Arg[] = "-fapinotes-cache-path=";
     APINotesCachePath.insert(APINotesCachePath.begin(), Arg, Arg + strlen(Arg));
     CmdArgs.push_back(Args.MakeArgString(APINotesCachePath));
+
+    Args.AddLastArg(CmdArgs, options::OPT_fapinotes_swift_version);
   }
 
   // -fblocks=0 is default.

--- a/lib/Sema/SemaAPINotes.cpp
+++ b/lib/Sema/SemaAPINotes.cpp
@@ -241,20 +241,22 @@ static void ProcessAPINotes(Sema &S, Decl *D,
                             const api_notes::CommonTypeInfo &info,
                             VersionedInfoRole role) {
   // swift_bridge
-  if (!info.getSwiftBridge().empty()) {
-    handleAPINotedAttribute<SwiftBridgeAttr>(S, D, true, role, [&] {
+  if (auto swiftBridge = info.getSwiftBridge()) {
+    handleAPINotedAttribute<SwiftBridgeAttr>(S, D, !swiftBridge->empty(), role,
+                                             [&] {
       return SwiftBridgeAttr::CreateImplicit(S.Context,
                                              CopyString(S.Context,
-                                                        info.getSwiftBridge()));
+                                                        *swiftBridge));
     });
   }
 
   // ns_error_domain
-  if (!info.getNSErrorDomain().empty()) {
-    handleAPINotedAttribute<NSErrorDomainAttr>(S, D, true, role, [&] {
+  if (auto nsErrorDomain = info.getNSErrorDomain()) {
+    handleAPINotedAttribute<NSErrorDomainAttr>(S, D, !nsErrorDomain->empty(),
+                                               role, [&] {
       return NSErrorDomainAttr::CreateImplicit(
                S.Context,
-               &S.Context.Idents.get(info.getNSErrorDomain()));
+               &S.Context.Idents.get(*nsErrorDomain));
     });
   }
 
@@ -281,8 +283,8 @@ static void ProcessAPINotes(Sema &S, ParmVarDecl *D,
                             const api_notes::ParamInfo &info,
                             VersionedInfoRole role) {
   // noescape
-  if (info.isNoEscape()) {
-    handleAPINotedAttribute<NoEscapeAttr>(S, D, true, role, [&] {
+  if (auto noescape = info.isNoEscape()) {
+    handleAPINotedAttribute<NoEscapeAttr>(S, D, *noescape, role, [&] {
       return NoEscapeAttr::CreateImplicit(S.Context);
     });
   }

--- a/test/APINotes/Inputs/Frameworks/SomeKit.framework/APINotes/SomeKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/SomeKit.framework/APINotes/SomeKit.apinotes
@@ -40,3 +40,10 @@ SwiftVersions:
             MethodKind:      Instance
             NullabilityOfRet: O
             Nullability:      [ O, S ]
+        Properties:
+          - Name: explicitNonnullInstance
+            PropertyKind:    Instance
+            Nullability:     O
+          - Name: explicitNullableInstance
+            PropertyKind:    Instance
+            Nullability:     N

--- a/test/APINotes/Inputs/Frameworks/SomeKit.framework/Headers/SomeKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/SomeKit.framework/Headers/SomeKit.apinotes
@@ -40,3 +40,10 @@ SwiftVersions:
             MethodKind:      Instance
             NullabilityOfRet: O
             Nullability:      [ O, S ]
+        Properties:
+          - Name: explicitNonnullInstance
+            PropertyKind:    Instance
+            Nullability:     O
+          - Name: explicitNullableInstance
+            PropertyKind:    Instance
+            Nullability:     N

--- a/test/APINotes/Inputs/Frameworks/SomeKit.framework/Headers/SomeKit.h
+++ b/test/APINotes/Inputs/Frameworks/SomeKit.framework/Headers/SomeKit.h
@@ -35,4 +35,6 @@ __attribute__((objc_root_class))
 @property (class, nonatomic, readwrite, retain) A *nonnullABoth;
 @end
 
+#import <SomeKit/SomeKitExplicitNullability.h>
+
 #endif

--- a/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.apinotes
@@ -1,0 +1,6 @@
+Name: SomeKit
+SwiftVersions:
+  - Version: 3.0
+    Functions:
+      - Name: moveToPoint
+        SwiftName: 'moveTo(a:b:)'

--- a/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.apinotes
@@ -1,6 +1,18 @@
 Name: SomeKit
 SwiftVersions:
   - Version: 3.0
+    Classes:
+      - Name: MyReferenceType
+        SwiftBridge: ''
     Functions:
       - Name: moveToPoint
         SwiftName: 'moveTo(a:b:)'
+      - Name: acceptClosure
+        Parameters:      
+          - Position:        0
+            NoEscape:        false
+    Tags:
+      - Name: MyErrorCode
+        NSErrorDomain: ''
+
+  

--- a/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.h
+++ b/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.h
@@ -1,0 +1,1 @@
+void moveToPoint(double x, double y) __attribute__((swift_name("moveTo(x:y:)")));

--- a/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.h
+++ b/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.h
@@ -1,1 +1,15 @@
 void moveToPoint(double x, double y) __attribute__((swift_name("moveTo(x:y:)")));
+
+void acceptClosure(void (^ __attribute__((noescape)) block)(void));
+
+@class NSString;
+
+extern NSString *MyErrorDomain;
+
+enum __attribute__((ns_error_domain(MyErrorDomain))) MyErrorCode {
+  MyErrorCodeFailed = 1
+};
+
+__attribute__((swift_bridge("MyValueType")))
+@interface MyReferenceType
+@end

--- a/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Modules/module.modulemap
+++ b/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module VersionedKit {
+  umbrella header "VersionedKit.h"
+  export *
+  module * { export * }
+}

--- a/test/APINotes/Inputs/roundtrip.apinotes
+++ b/test/APINotes/Inputs/roundtrip.apinotes
@@ -9,8 +9,6 @@ Classes:
     AvailabilityMsg: ''
     SwiftPrivate:    false
     SwiftName:       ''
-    SwiftBridge:     ''
-    NSErrorDomain:   ''
     Methods:         
       - Selector:        'cellWithImage:'
         MethodKind:      Class
@@ -62,7 +60,6 @@ Classes:
     SwiftPrivate:    false
     SwiftName:       ''
     SwiftBridge:     View
-    NSErrorDomain:   ''
     Methods:         
       - Selector:        'addSubview:'
         MethodKind:      Instance
@@ -78,7 +75,6 @@ Classes:
           - Position:        0
             NoEscape:        false
           - Position:        1
-            NoEscape:        false
           - Position:        2
             NoEscape:        true
         Nullability:     [ N, N, O ]
@@ -136,14 +132,12 @@ Tags:
     AvailabilityMsg: ''
     SwiftPrivate:    false
     SwiftName:       SomeEnum
-    SwiftBridge:     ''
     NSErrorDomain:   some_error_domain
   - Name:            NSSomeStruct
     Availability:    available
     AvailabilityMsg: ''
     SwiftPrivate:    false
     SwiftName:       SomeStruct
-    SwiftBridge:     ''
     NSErrorDomain:   ''
 Typedefs:        
   - Name:            NSTypedef
@@ -152,7 +146,6 @@ Typedefs:
     SwiftPrivate:    false
     SwiftName:       Typedef
     SwiftBridge:     ''
-    NSErrorDomain:   ''
 SwiftVersions:   
   - Version:         3.0
     Classes:         
@@ -162,7 +155,6 @@ SwiftVersions:
         SwiftPrivate:    false
         SwiftName:       NSBox
         SwiftBridge:     ''
-        NSErrorDomain:   ''
         Methods:         
           - Selector:        init
             MethodKind:      Instance

--- a/test/APINotes/nullability.m
+++ b/test/APINotes/nullability.m
@@ -3,7 +3,7 @@
 
 // Test with Swift version 3.0. This should only affect the few APIs that have an entry in the 3.0 tables.
 
-// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -fapinotes-swift-version=3.0 -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -verify -DSWIFT_VERSION_3_0
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -fapinotes-swift-version=3.0 -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -verify -DSWIFT_VERSION_3_0 -fmodules-ignore-macro=SWIFT_VERSION_3_0
 
 #import <SomeKit/SomeKit.h>
 
@@ -28,6 +28,16 @@ int main() {
   [A setNonnullABoth: 0]; // expected-warning{{null passed to a callee that requires a non-null argument}}
 
   [a setInternalProperty: 0]; // expected-warning{{null passed to a callee that requires a non-null argument}}
+
+#if SWIFT_VERSION_3_0
+  // Version 3 information overrides header information.
+  [a setExplicitNonnullInstance: 0]; //  okay
+  [a setExplicitNullableInstance: 0]; // expected-warning{{null passed to a callee that requires a non-null argument}}
+#else
+  // Header information overrides unversioned information.
+  [a setExplicitNonnullInstance: 0]; // expected-warning{{null passed to a callee that requires a non-null argument}}
+  [a setExplicitNullableInstance: 0]; // okay
+#endif
 
   return 0;
 }

--- a/test/APINotes/versioned.m
+++ b/test/APINotes/versioned.m
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t && mkdir -p %t
 
 // Build and check the unversioned module file.
-// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Unversioned -fdisable-module-hash -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Unversioned -fdisable-module-hash -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s
 // RUN: %clang_cc1 -ast-print %t/ModulesCache/Unversioned/VersionedKit.pcm | FileCheck -check-prefix=CHECK-UNVERSIONED %s
 
 // Build and check the versioned module file.
-// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Versioned -fdisable-module-hash -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -fapinotes-swift-version=3.0 -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Versioned -fdisable-module-hash -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -fapinotes-swift-version=3.0 -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s
 // RUN: %clang_cc1 -ast-print %t/ModulesCache/Versioned/VersionedKit.pcm | FileCheck -check-prefix=CHECK-VERSIONED %s
 
 #import <VersionedKit/VersionedKit.h>
@@ -13,3 +13,19 @@
 // CHECK-UNVERSIONED: void moveToPoint(double x, double y) __attribute__((swift_name("moveTo(x:y:)")));
 // CHECK-VERSIONED: void moveToPoint(double x, double y) __attribute__((swift_name("moveTo(a:b:)")));
 
+// CHECK-UNVERSIONED: void acceptClosure(void (^block)(void) __attribute__((noescape)));
+// CHECK-VERSIONED: void acceptClosure(void (^block)(void));
+
+// CHECK-UNVERSIONED:      enum MyErrorCode {
+// CHECK-UNVERSIONED-NEXT:     MyErrorCodeFailed = 1
+// CHECK-UNVERSIONED-NEXT: } __attribute__((ns_error_domain(MyErrorDomain)));
+
+// CHECK-UNVERSIONED: __attribute__((swift_bridge("MyValueType")))
+// CHECK-UNVERSIONED: @interface MyReferenceType
+
+// CHECK-VERSIONED:      enum MyErrorCode {
+// CHECK-VERSIONED-NEXT:     MyErrorCodeFailed = 1
+// CHECK-VERSIONED-NEXT: };
+
+// CHECK-VERSIONED-NOT: __attribute__((swift_bridge("MyValueType")))
+// CHECK-VERSIONED: @interface MyReferenceType

--- a/test/APINotes/versioned.m
+++ b/test/APINotes/versioned.m
@@ -1,0 +1,15 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// Build and check the unversioned module file.
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Unversioned -fdisable-module-hash -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s
+// RUN: %clang_cc1 -ast-print %t/ModulesCache/Unversioned/VersionedKit.pcm | FileCheck -check-prefix=CHECK-UNVERSIONED %s
+
+// Build and check the versioned module file.
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Versioned -fdisable-module-hash -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -fapinotes-swift-version=3.0 -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s
+// RUN: %clang_cc1 -ast-print %t/ModulesCache/Versioned/VersionedKit.pcm | FileCheck -check-prefix=CHECK-VERSIONED %s
+
+#import <VersionedKit/VersionedKit.h>
+
+// CHECK-UNVERSIONED: void moveToPoint(double x, double y) __attribute__((swift_name("moveTo(x:y:)")));
+// CHECK-VERSIONED: void moveToPoint(double x, double y) __attribute__((swift_name("moveTo(a:b:)")));
+


### PR DESCRIPTION
Allow versioned API notes (e.g., the API notes specified for Swift version 3.0) to override information explicitly specified in headers, allowing headers to be the "truth" moving forward while API notes provide backward compatibility.
