### PR TITLE
Yet more API notes files

### DIFF
--- a/include/clang/APINotes/Types.h
+++ b/include/clang/APINotes/Types.h
@@ -70,19 +70,42 @@ public:
   /// Whether this entity is marked unavailable in Swift.
   unsigned UnavailableInSwift : 1;
 
+private:
+  /// Whether SwiftPrivate was specified.
+  unsigned SwiftPrivateSpecified : 1;
+
   /// Whether this entity is considered "private" to a Swift overlay.
   unsigned SwiftPrivate : 1;
 
+public:
   /// Swift name of this entity.
   std::string SwiftName;
 
-  CommonEntityInfo() : Unavailable(0), UnavailableInSwift(0), SwiftPrivate(0) { }
+  CommonEntityInfo()
+    : Unavailable(0), UnavailableInSwift(0), SwiftPrivateSpecified(0),
+      SwiftPrivate(0) { }
+
+  Optional<bool> isSwiftPrivate() const {
+    if (!SwiftPrivateSpecified) return None;
+    return SwiftPrivate;
+  }
+
+  void setSwiftPrivate(Optional<bool> swiftPrivate) {
+    if (swiftPrivate) {
+      SwiftPrivateSpecified = 1;
+      SwiftPrivate = *swiftPrivate;
+    } else {
+      SwiftPrivateSpecified = 0;
+      SwiftPrivate = 0;
+    }
+  }
 
   friend bool operator==(const CommonEntityInfo &lhs,
                          const CommonEntityInfo &rhs) {
     return lhs.UnavailableMsg == rhs.UnavailableMsg &&
            lhs.Unavailable == rhs.Unavailable &&
            lhs.UnavailableInSwift == rhs.UnavailableInSwift &&
+           lhs.SwiftPrivateSpecified == rhs.SwiftPrivateSpecified &&
            lhs.SwiftPrivate == rhs.SwiftPrivate &&
            lhs.SwiftName == rhs.SwiftName;
   }
@@ -111,8 +134,10 @@ public:
       }
     }
 
-    if (rhs.SwiftPrivate)
-      lhs.SwiftPrivate = true;
+    if (rhs.SwiftPrivateSpecified && !lhs.SwiftPrivateSpecified) {
+      lhs.SwiftPrivateSpecified = 1;
+      lhs.SwiftPrivate = rhs.SwiftPrivate;
+    }
 
     if (rhs.SwiftName.length() != 0 &&
         lhs.SwiftName.length() == 0)

--- a/include/clang/APINotes/Types.h
+++ b/include/clang/APINotes/Types.h
@@ -585,9 +585,18 @@ public:
   TagInfo() : CommonTypeInfo() { }
 };
 
+/// The kind of a swift_wrapper/swift_newtype.
+enum class SwiftWrapperKind {
+  None,
+  Struct,
+  Enum
+};
+
 /// Describes API notes data for a typedef.
 class TypedefInfo : public CommonTypeInfo {
 public:
+  Optional<SwiftWrapperKind> SwiftWrapper;
+
   TypedefInfo() : CommonTypeInfo() { }
 };
 

--- a/lib/APINotes/APINotesFormat.h
+++ b/lib/APINotes/APINotesFormat.h
@@ -36,7 +36,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// API notes file minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t VERSION_MINOR = 18;  // three-state SwiftPrivate
+const uint16_t VERSION_MINOR = 19;  // SwiftWrapper
 
 using IdentifierID = PointerEmbeddedInt<unsigned, 31>;
 using IdentifierIDField = BCVBR<16>;

--- a/lib/APINotes/APINotesFormat.h
+++ b/lib/APINotes/APINotesFormat.h
@@ -36,7 +36,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// API notes file minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t VERSION_MINOR = 17;  // optional NSErrorDomain
+const uint16_t VERSION_MINOR = 18;  // three-state SwiftPrivate
 
 using IdentifierID = PointerEmbeddedInt<unsigned, 31>;
 using IdentifierIDField = BCVBR<16>;

--- a/lib/APINotes/APINotesReader.cpp
+++ b/lib/APINotes/APINotesReader.cpp
@@ -104,7 +104,8 @@ namespace {
     uint8_t unavailableBits = *data++;
     info.Unavailable = (unavailableBits >> 1) & 0x01;
     info.UnavailableInSwift = unavailableBits & 0x01;
-    info.SwiftPrivate = (unavailableBits >> 2) & 0x01;
+    if ((unavailableBits >> 2) & 0x01)
+      info.setSwiftPrivate(static_cast<bool>((unavailableBits >> 3) & 0x01));
 
     unsigned msgLength = endian::readNext<uint16_t, little, unaligned>(data);
     info.UnavailableMsg

--- a/lib/APINotes/APINotesReader.cpp
+++ b/lib/APINotes/APINotesReader.cpp
@@ -88,7 +88,7 @@ namespace {
       result.reserve(numElements);
       for (unsigned i = 0; i != numElements; ++i) {
         auto version = readVersionTuple(data);
-        auto dataBefore = data; (void)data;
+        auto dataBefore = data; (void)dataBefore;
         auto unversionedData = Derived::readUnversioned(key, data);
         assert(data != dataBefore
                && "Unversioned data reader didn't move pointer");

--- a/lib/APINotes/APINotesReader.cpp
+++ b/lib/APINotes/APINotesReader.cpp
@@ -479,6 +479,12 @@ namespace {
     static TypedefInfo readUnversioned(internal_key_type key,
                                        const uint8_t *&data) {
       TypedefInfo info;
+
+      uint8_t payload = *data++;
+      if (payload > 0) {
+        info.SwiftWrapper = static_cast<SwiftWrapperKind>((payload & 0x3) - 1);
+      }
+
       readCommonTypeInfo(data, info);
       return info;
     }

--- a/lib/APINotes/APINotesWriter.cpp
+++ b/lib/APINotes/APINotesWriter.cpp
@@ -331,9 +331,18 @@ namespace {
   static void emitCommonEntityInfo(raw_ostream &out,
                                    const CommonEntityInfo &info) {
     endian::Writer<little> writer(out);
-    writer.write<uint8_t>(info.SwiftPrivate << 2
-                          | info.Unavailable << 1 
-                          | info.UnavailableInSwift);
+    uint8_t payload = 0;
+    if (auto swiftPrivate = info.isSwiftPrivate()) {
+      payload |= 0x01;
+      if (*swiftPrivate) payload |= 0x02;
+    }
+    payload <<= 1;
+    payload |= info.Unavailable;
+    payload <<= 1;
+    payload |= info.UnavailableInSwift;
+
+    writer.write<uint8_t>(payload);
+
     writer.write<uint16_t>(info.UnavailableMsg.size());
     out.write(info.UnavailableMsg.c_str(), info.UnavailableMsg.size());
     writer.write<uint16_t>(info.SwiftName.size());

--- a/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -183,7 +183,7 @@ namespace {
     NullabilitySeq Nullability;
     llvm::Optional<NullabilityKind> NullabilityOfRet;
     AvailabilityItem Availability;
-    bool SwiftPrivate = false;
+    Optional<bool> SwiftPrivate;
     StringRef SwiftName;
     api_notes::FactoryAsInitKind FactoryAsInit
       = api_notes::FactoryAsInitKind::Infer;
@@ -197,7 +197,7 @@ namespace {
     llvm::Optional<MethodKind> Kind;
     llvm::Optional<NullabilityKind> Nullability;
     AvailabilityItem Availability;
-    bool SwiftPrivate = false;
+    Optional<bool> SwiftPrivate;
     StringRef SwiftName;
   };
   typedef std::vector<Property> PropertiesSeq;
@@ -206,7 +206,7 @@ namespace {
     StringRef Name;
     bool AuditedForNullability = false;
     AvailabilityItem Availability;
-    bool SwiftPrivate = false;
+    Optional<bool> SwiftPrivate;
     StringRef SwiftName;
     Optional<StringRef> SwiftBridge;
     Optional<StringRef> NSErrorDomain;
@@ -221,7 +221,7 @@ namespace {
     NullabilitySeq Nullability;
     llvm::Optional<NullabilityKind> NullabilityOfRet;
     AvailabilityItem Availability;
-    bool SwiftPrivate = false;
+    Optional<bool> SwiftPrivate;
     StringRef SwiftName;
   };
   typedef std::vector<Function> FunctionsSeq;
@@ -230,7 +230,7 @@ namespace {
     StringRef Name;
     llvm::Optional<NullabilityKind> Nullability;
     AvailabilityItem Availability;
-    bool SwiftPrivate = false;
+    Optional<bool> SwiftPrivate;
     StringRef SwiftName;
   };
   typedef std::vector<GlobalVariable> GlobalVariablesSeq;
@@ -238,7 +238,7 @@ namespace {
   struct EnumConstant {
     StringRef Name;
     AvailabilityItem Availability;
-    bool SwiftPrivate = false;
+    Optional<bool> SwiftPrivate;
     StringRef SwiftName;
   };
   typedef std::vector<EnumConstant> EnumConstantsSeq;
@@ -247,7 +247,7 @@ namespace {
     StringRef Name;
     AvailabilityItem Availability;
     StringRef SwiftName;
-    bool SwiftPrivate = false;
+    Optional<bool> SwiftPrivate;
     Optional<StringRef> SwiftBridge;
     Optional<StringRef> NSErrorDomain;
   };
@@ -257,7 +257,7 @@ namespace {
     StringRef Name;
     AvailabilityItem Availability;
     StringRef SwiftName;
-    bool SwiftPrivate = false;
+    Optional<bool> SwiftPrivate;
     Optional<StringRef> SwiftBridge;
     Optional<StringRef> NSErrorDomain;
   };
@@ -652,7 +652,7 @@ namespace {
         return true;
 
       convertAvailability(common.Availability, info, apiName);
-      info.SwiftPrivate = common.SwiftPrivate;
+      info.setSwiftPrivate(common.SwiftPrivate);
       info.SwiftName = common.SwiftName;
       return false;
     }
@@ -769,7 +769,7 @@ namespace {
         if (!isAvailable(prop.Availability))
           continue;
         convertAvailability(prop.Availability, pInfo, prop.Name);
-        pInfo.SwiftPrivate = prop.SwiftPrivate;
+        pInfo.setSwiftPrivate(prop.SwiftPrivate);
         pInfo.SwiftName = prop.SwiftName;
         if (prop.Nullability)
           pInfo.setNullabilityAudited(*prop.Nullability);
@@ -825,7 +825,7 @@ namespace {
         if (!isAvailable(global.Availability))
           continue;
         convertAvailability(global.Availability, info, global.Name);
-        info.SwiftPrivate = global.SwiftPrivate;
+        info.setSwiftPrivate(global.SwiftPrivate);
         info.SwiftName = global.SwiftName;
         if (global.Nullability)
           info.setNullabilityAudited(*global.Nullability);
@@ -846,7 +846,7 @@ namespace {
         if (!isAvailable(function.Availability))
           continue;
         convertAvailability(function.Availability, info, function.Name);
-        info.SwiftPrivate = function.SwiftPrivate;
+        info.setSwiftPrivate(function.SwiftPrivate);
         info.SwiftName = function.SwiftName;
         convertParams(function.Params, info);
         convertNullability(function.Nullability,
@@ -870,7 +870,7 @@ namespace {
         if (!isAvailable(enumConstant.Availability))
           continue;
         convertAvailability(enumConstant.Availability, info, enumConstant.Name);
-        info.SwiftPrivate = enumConstant.SwiftPrivate;
+        info.setSwiftPrivate(enumConstant.SwiftPrivate);
         info.SwiftName = enumConstant.SwiftName;
         Writer->addEnumConstant(enumConstant.Name, info, swiftVersion);
       }
@@ -1050,7 +1050,7 @@ namespace {
     template<typename T>
     void handleCommon(T &record, const CommonEntityInfo &info) {
       handleAvailability(record.Availability, info);
-      record.SwiftPrivate = info.SwiftPrivate;
+      record.SwiftPrivate = info.isSwiftPrivate();
       record.SwiftName = copyString(info.SwiftName);
     }
 

--- a/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -260,6 +260,7 @@ namespace {
     Optional<bool> SwiftPrivate;
     Optional<StringRef> SwiftBridge;
     Optional<StringRef> NSErrorDomain;
+    Optional<api_notes::SwiftWrapperKind> SwiftWrapper;
   };
   typedef std::vector<Typedef> TypedefsSeq;
 
@@ -346,6 +347,15 @@ namespace llvm {
         io.enumCase(value, "none",      APIAvailability::None);
         io.enumCase(value, "nonswift",  APIAvailability::NonSwift);
         io.enumCase(value, "available", APIAvailability::Available);
+      }
+    };
+
+    template<>
+    struct ScalarEnumerationTraits<api_notes::SwiftWrapperKind> {
+      static void enumeration(IO &io, api_notes::SwiftWrapperKind &value) {
+        io.enumCase(value, "none",      api_notes::SwiftWrapperKind::None);
+        io.enumCase(value, "struct",    api_notes::SwiftWrapperKind::Struct);
+        io.enumCase(value, "enum",      api_notes::SwiftWrapperKind::Enum);
       }
     };
 
@@ -489,6 +499,7 @@ namespace llvm {
         io.mapOptional("SwiftName",             t.SwiftName);
         io.mapOptional("SwiftBridge",           t.SwiftBridge);
         io.mapOptional("NSErrorDomain",         t.NSErrorDomain);
+        io.mapOptional("SwiftWrapper",         t.SwiftWrapper);
       }
     };
 
@@ -903,7 +914,8 @@ namespace {
         TypedefInfo typedefInfo;
         if (convertCommonType(t, typedefInfo, t.Name))
           continue;
-        
+        typedefInfo.SwiftWrapper = t.SwiftWrapper;
+
         Writer->addTypedef(t.Name, typedefInfo, swiftVersion);
       }
     }
@@ -1246,6 +1258,7 @@ namespace {
       Typedef td;
       td.Name = name;
       handleCommonType(td, info);
+      td.SwiftWrapper = info.SwiftWrapper;
       auto &items = getTopLevelItems(swiftVersion);
       items.Typedefs.push_back(td);
     }

--- a/lib/Sema/SemaAPINotes.cpp
+++ b/lib/Sema/SemaAPINotes.cpp
@@ -213,8 +213,8 @@ static void ProcessAPINotes(Sema &S, Decl *D,
   }
 
   // swift_private
-  if (info.SwiftPrivate) {
-    handleAPINotedAttribute<SwiftPrivateAttr>(S, D, true, role, [&] {
+  if (auto swiftPrivate = info.isSwiftPrivate()) {
+    handleAPINotedAttribute<SwiftPrivateAttr>(S, D, *swiftPrivate, role, [&] {
       return SwiftPrivateAttr::CreateImplicit(S.Context);
     });
   }

--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -6440,6 +6440,7 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     break;
   case AttributeList::AT_SwiftNewtype:
     handleSwiftNewtypeAttr(S, D, Attr);
+    break;
   // XRay attributes.
   case AttributeList::AT_XRayInstrument:
     handleSimpleAttribute<XRayInstrumentAttr>(S, D, Attr);

--- a/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.apinotes
@@ -16,5 +16,9 @@ SwiftVersions:
     Tags:
       - Name: MyErrorCode
         NSErrorDomain: ''
+    Typedefs:
+      - Name: MyDoubleWrapper
+        SwiftWrapper: none
+
 
   

--- a/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.apinotes
@@ -11,6 +11,8 @@ SwiftVersions:
         Parameters:      
           - Position:        0
             NoEscape:        false
+      - Name: privateFunc
+        SwiftPrivate: false
     Tags:
       - Name: MyErrorCode
         NSErrorDomain: ''

--- a/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.h
+++ b/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.h
@@ -13,3 +13,5 @@ enum __attribute__((ns_error_domain(MyErrorDomain))) MyErrorCode {
 __attribute__((swift_bridge("MyValueType")))
 @interface MyReferenceType
 @end
+
+void privateFunc(void) __attribute__((swift_private));

--- a/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.h
+++ b/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.h
@@ -15,3 +15,5 @@ __attribute__((swift_bridge("MyValueType")))
 @end
 
 void privateFunc(void) __attribute__((swift_private));
+
+typedef double MyDoubleWrapper __attribute__((swift_wrapper(struct)));

--- a/test/APINotes/Inputs/roundtrip.apinotes
+++ b/test/APINotes/Inputs/roundtrip.apinotes
@@ -81,7 +81,6 @@ Classes:
         NullabilityOfRet: N
         Availability:    available
         AvailabilityMsg: ''
-        SwiftPrivate:    false
         SwiftName:       ''
       - Selector:        'beginDraggingSessionWithItems:event:source:'
         MethodKind:      Instance
@@ -97,7 +96,6 @@ Classes:
         Nullability:     O
         Availability:    available
         AvailabilityMsg: ''
-        SwiftPrivate:    false
         SwiftName:       enclosing
       - Name:            makeBackingLayer
         PropertyKind:    Class
@@ -111,7 +109,6 @@ Functions:
     NullabilityOfRet: N
     Availability:    available
     AvailabilityMsg: ''
-    SwiftPrivate:    false
     SwiftName:       'availableWindowDepths()'
 Globals:         
   - Name:            NSCalibratedWhiteColorSpace

--- a/test/APINotes/Inputs/roundtrip.apinotes
+++ b/test/APINotes/Inputs/roundtrip.apinotes
@@ -143,6 +143,7 @@ Typedefs:
     SwiftPrivate:    false
     SwiftName:       Typedef
     SwiftBridge:     ''
+    SwiftWrapper:    struct
 SwiftVersions:   
   - Version:         3.0
     Classes:         

--- a/test/APINotes/versioned.m
+++ b/test/APINotes/versioned.m
@@ -25,6 +25,8 @@
 
 // CHECK-UNVERSIONED: void privateFunc() __attribute__((swift_private));
 
+// CHECK-UNVERSIONED: typedef double MyDoubleWrapper __attribute__((swift_wrapper("struct")));
+
 // CHECK-VERSIONED:      enum MyErrorCode {
 // CHECK-VERSIONED-NEXT:     MyErrorCodeFailed = 1
 // CHECK-VERSIONED-NEXT: };
@@ -33,3 +35,5 @@
 // CHECK-VERSIONED: @interface MyReferenceType
 
 // CHECK-VERSIONED: void privateFunc();
+
+// CHECK-VERSIONED: typedef double MyDoubleWrapper;

--- a/test/APINotes/versioned.m
+++ b/test/APINotes/versioned.m
@@ -23,9 +23,13 @@
 // CHECK-UNVERSIONED: __attribute__((swift_bridge("MyValueType")))
 // CHECK-UNVERSIONED: @interface MyReferenceType
 
+// CHECK-UNVERSIONED: void privateFunc() __attribute__((swift_private));
+
 // CHECK-VERSIONED:      enum MyErrorCode {
 // CHECK-VERSIONED-NEXT:     MyErrorCodeFailed = 1
 // CHECK-VERSIONED-NEXT: };
 
 // CHECK-VERSIONED-NOT: __attribute__((swift_bridge("MyValueType")))
 // CHECK-VERSIONED: @interface MyReferenceType
+
+// CHECK-VERSIONED: void privateFunc();


### PR DESCRIPTION
A couple of random fixes related to API notes:
- Suppress an unused-variable warning when assertions are disabled
- Make SwiftPrivate three-state, so we can undo it via versioned API notes
- Fix a bad merge where swift_newtype implied xray_always_instrument!
- Add support for SwiftWrapper via API notes, which can be undone via versioned API notes
