### PR TITLE
[AST] Remove superfluous docblock change

### DIFF
--- a/include/clang/AST/DeclBase.h
+++ b/include/clang/AST/DeclBase.h
@@ -605,7 +605,7 @@ public:
   /// the given declaration (e.g., preferring 'unavailable' to
   /// 'deprecated').
   ///
-  /// \param[out] Message If non-NULL and the result is not \c
+  /// \param Message If non-NULL and the result is not \c
   /// AR_Available, will be set to a (possibly empty) message
   /// describing why the declaration has not been introduced, is
   /// deprecated, or is unavailable.


### PR DESCRIPTION
Upstream Clang documents the `Message` parameter as simply `\param`, while Swift's fork of Clang documents it as `\param[out]`. Although `\param[out]` may be more correct, the change to the documentation should be made in upstream Clang, not Swift Clang.

Furthermore, upstream Clang does not appear to have a strong convention as to the use of `\param[out]`: of 4616 instances of `\param`, only 49 are denoted as `\param[out]`.

---

This reduces the diff between upstream and Swift Clang, from 156 modified files to 155.
