### PR TITLE
Fix use-of-temporary with StringRef in code coverage

### DIFF
--- a/lib/CodeGen/CoverageMappingGen.cpp
+++ b/lib/CodeGen/CoverageMappingGen.cpp
@@ -1039,10 +1039,15 @@ void CoverageMappingModuleGen::addFunctionMappingRecord(
     std::vector<StringRef> Filenames;
     std::vector<CounterExpression> Expressions;
     std::vector<CounterMappingRegion> Regions;
+    llvm::SmallVector<std::string, 16> FilenameStrs;
     llvm::SmallVector<StringRef, 16> FilenameRefs;
+    FilenameStrs.resize(FileEntries.size());
     FilenameRefs.resize(FileEntries.size());
-    for (const auto &Entry : FileEntries)
-      FilenameRefs[Entry.second] = normalizeFilename(Entry.first->getName());
+    for (const auto &Entry : FileEntries) {
+      auto I = Entry.second;
+      FilenameStrs[I] = normalizeFilename(Entry.first->getName());
+      FilenameRefs[I] = FilenameStrs[I];
+    }
     RawCoverageMappingReader Reader(CoverageMapping, FilenameRefs, Filenames,
                                     Expressions, Regions);
     if (Reader.read())


### PR DESCRIPTION
Caught by adding a similar check to StringRef as r283798 did for ArrayRef. Reviewed by @vedantk as https://reviews.llvm.org/D26317.