### PR TITLE
[APINotes] Remove VersionedInfoRole

### DIFF
--- a/include/clang/APINotes/APINotesReader.h
+++ b/include/clang/APINotes/APINotesReader.h
@@ -25,20 +25,6 @@
 namespace clang {
 namespace api_notes {
 
-/// Describes the role of a specific bit of versioned information.
-enum class VersionedInfoRole : unsigned {
-  /// Augment the AST, but do not override information explicitly specified
-  /// in the source code.
-  AugmentSource,
-
-  /// Replace information that may have been explicitly specified in the source
-  /// code.
-  ReplaceSource,
-
-  /// Describes an alternate version of this information.
-  Versioned,
-};
-
 /// A class that reads API notes data from a binary file that was written by
 /// the \c APINotesWriter.
 class APINotesReader {
@@ -94,9 +80,6 @@ public:
     /// Swift version, or \c Results.size() if nothing matched.
     unsigned Selected;
 
-    /// The role of the selected index.
-    VersionedInfoRole SelectedRole;
-
   public:
     /// Form an empty set of versioned information.
     VersionedInfo(llvm::NoneType) : Selected(0) { }
@@ -120,11 +103,6 @@ public:
     Optional<unsigned> getSelected() const {
       if (Selected == Results.size()) return None;
       return Selected;
-    }
-
-    /// Describes the role of the selected entity.
-    VersionedInfoRole getSelectedRole() const {
-      return SelectedRole;
     }
 
     /// Return the number of versioned results we know about.

--- a/include/clang/APINotes/Types.h
+++ b/include/clang/APINotes/Types.h
@@ -38,16 +38,6 @@ using llvm::StringRef;
 using llvm::Optional;
 using llvm::None;
 
-/// Describes whether to classify a factory method as an initializer.
-enum class FactoryAsInitKind {
-  /// Infer based on name and type (the default).
-  Infer,
-  /// Treat as a class method.
-  AsClassMethod,
-  /// Treat as an initializer.
-  AsInitializer
-};
-
 /// Opaque context ID used to refer to an Objective-C class or protocol.
 class ContextID {
 public:
@@ -556,30 +546,17 @@ public:
   /// Whether this is a designated initializer of its class.
   unsigned DesignatedInit : 1;
 
-  /// Whether to treat this method as a factory or initializer.
-  unsigned FactoryAsInit : 2;
-
   /// Whether this is a required initializer.
   unsigned Required : 1;
 
   ObjCMethodInfo()
     : FunctionInfo(),
       DesignatedInit(false),
-      FactoryAsInit(static_cast<unsigned>(FactoryAsInitKind::Infer)),
       Required(false) { }
-
-  FactoryAsInitKind getFactoryAsInitKind() const {
-    return static_cast<FactoryAsInitKind>(FactoryAsInit);
-  }
-
-  void setFactoryAsInitKind(FactoryAsInitKind kind) {
-    FactoryAsInit = static_cast<unsigned>(kind);
-  }
 
   friend bool operator==(const ObjCMethodInfo &lhs, const ObjCMethodInfo &rhs) {
     return static_cast<const FunctionInfo &>(lhs) == rhs &&
            lhs.DesignatedInit == rhs.DesignatedInit &&
-           lhs.FactoryAsInit == rhs.FactoryAsInit &&
            lhs.Required == rhs.Required;
   }
 

--- a/include/clang/Basic/Attr.td
+++ b/include/clang/Basic/Attr.td
@@ -1487,14 +1487,6 @@ def SwiftPrivate : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
-def SwiftSuppressFactoryAsInit : InheritableAttr { 
-  // This attribute has no spellings as it is only ever created implicitly
-  // from API notes.
-  let Spellings = [];
-  let SemaHandler = 0; 
-  let Documentation = [Undocumented];
-}
-
 def SwiftImportPropertyAsAccessors : InheritableAttr { 
   // This attribute has no spellings as it is only ever created implicitly
   // from API notes.

--- a/lib/APINotes/APINotesReader.cpp
+++ b/lib/APINotes/APINotesReader.cpp
@@ -1471,14 +1471,10 @@ APINotesReader::VersionedInfo<T>::VersionedInfo(
   // Look for an exact version match.
   Optional<unsigned> unversioned;
   Selected = Results.size();
-  SelectedRole = VersionedInfoRole::Versioned;
 
   for (unsigned i = 0, n = Results.size(); i != n; ++i) {
     if (Results[i].first == version) {
       Selected = i;
-
-      if (version) SelectedRole = VersionedInfoRole::ReplaceSource;
-      else SelectedRole = VersionedInfoRole::AugmentSource;
       break;
     }
 
@@ -1492,9 +1488,8 @@ APINotesReader::VersionedInfo<T>::VersionedInfo(
   // unversioned result.
   if (Selected == Results.size() && unversioned) {
     Selected = *unversioned;
-    SelectedRole = VersionedInfoRole::AugmentSource;
   }
-  }
+}
 
 auto APINotesReader::lookupObjCClassID(StringRef name) -> Optional<ContextID> {
   if (!Impl.ObjCContextIDTable)

--- a/lib/APINotes/APINotesReader.cpp
+++ b/lib/APINotes/APINotesReader.cpp
@@ -353,8 +353,6 @@ namespace {
       payload >>= 1;
       info.DesignatedInit = payload & 0x01;
       payload >>= 1;
-      info.FactoryAsInit = payload & 0x03;
-      payload >>= 2;
 
       readFunctionInfo(data, info);
       return info;

--- a/lib/APINotes/APINotesWriter.cpp
+++ b/lib/APINotes/APINotesWriter.cpp
@@ -766,7 +766,7 @@ namespace {
     }
 
     void emitUnversionedInfo(raw_ostream &out, const ObjCMethodInfo &info) {
-      uint8_t payload = info.FactoryAsInit;
+      uint8_t payload = 0;
       payload = (payload << 1) | info.DesignatedInit;
       payload = (payload << 1) | info.Required;
       endian::Writer<little> writer(out);

--- a/lib/APINotes/Types.cpp
+++ b/lib/APINotes/Types.cpp
@@ -14,7 +14,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 void clang::api_notes::ObjCMethodInfo::dump(llvm::raw_ostream &os) {
-    os << DesignatedInit << " " << FactoryAsInit << " " << Unavailable << " "
+    os << DesignatedInit << " " << Unavailable << " "
        << NullabilityAudited << " " << NumAdjustedNullable << " "
        << NullabilityPayload << " " << UnavailableMsg << "\n";
 }

--- a/lib/Sema/SemaAPINotes.cpp
+++ b/lib/Sema/SemaAPINotes.cpp
@@ -568,14 +568,6 @@ static void ProcessAPINotes(Sema &S, ObjCMethodDecl *D,
     });
   }
 
-  // FIXME: This doesn't work well with versioned API notes.
-  if (metadata.Role == VersionedInfoRole::AugmentSource &&
-      info.getFactoryAsInitKind()
-        == api_notes::FactoryAsInitKind::AsClassMethod &&
-      !D->getAttr<SwiftNameAttr>()) {
-    D->addAttr(SwiftSuppressFactoryAsInitAttr::CreateImplicit(S.Context));
-  }
-
   // Handle common function information.
   ProcessAPINotes(S, FunctionOrMethod(D),
                   static_cast<const api_notes::FunctionInfo &>(info), metadata);

--- a/test/APINotes/Inputs/roundtrip.apinotes
+++ b/test/APINotes/Inputs/roundtrip.apinotes
@@ -16,7 +16,6 @@ Classes:
         AvailabilityMsg: ''
         SwiftPrivate:    false
         SwiftName:       ''
-        FactoryAsInit:   C
         ResultType:      id
       - Selector:        init
         MethodKind:      Instance


### PR DESCRIPTION
When API notes were first added, they would defer to the header when something was explicitly specified---for example, if the API notes had one set of nullability annotations from before the header was audited. This behavior didn't make sense for versioned API notes, however, where annotations needed for Swift 3 compatibility were intended to override the unversioned information in both the API notes and the header itself.

Now that the versioning of API notes is well-established, simplify things by having the API notes always "win"; that is, an annotation in API notes will always override what's in the headers.

While here, remove the obsolete `FactoryAsInit` key from the API notes dictionary. This never had a good implementation with versioned API notes anyway.

Getting this into a release branch or 'stable' depends on apple/swift#6901 and apple/swift#6907.