### PR TITLE
Fix compiler crash building APINotesYAMLCompiler in swift-clang with MSVC

### DIFF
--- a/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -164,7 +164,7 @@ namespace {
     AvailabilityItem() : Mode(APIAvailability::Available), Msg("") {}
   };
 
-  static llvm::Optional<NullabilityKind> AbsentNullability = llvm::None;
+  static llvm::Optional<NullabilityKind> AbsentNullability {};
   static llvm::Optional<NullabilityKind> DefaultNullability =
     NullabilityKind::NonNull;
   typedef std::vector<clang::NullabilityKind> NullabilitySeq;


### PR DESCRIPTION
This seems to have been reset in stable/swift-4.0-branch after the update to LLVM 4.0

This is a port of #45 (the other stuff seems to still be there with MSVC).

This fixes an MSVC crash,

@jrose-apple, please let me know what other branch this should go to. Do I submit another duplicate PR for stable or upstream-with-swift?
