### PR TITLE
[APINotes] Don't apply API notes to non-definitions of structs.

### DIFF
--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -13673,7 +13673,6 @@ CreateNewDecl:
 
   if (Attr)
     ProcessDeclAttributeList(S, New, Attr);
-  ProcessAPINotes(New);
 
   // If this has an identifier, add it to the scope stack.
   if (TUK == TUK_Friend) {

--- a/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.apinotes
@@ -1,0 +1,6 @@
+Name: SimpleKit
+Tags:
+- Name: RenamedAgainInAPINotesA
+  SwiftName: SuccessfullyRenamedA
+- Name: RenamedAgainInAPINotesB
+  SwiftName: SuccessfullyRenamedB

--- a/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.h
+++ b/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.h
@@ -1,0 +1,7 @@
+struct RenamedAgainInAPINotesA {
+  int field;
+} __attribute__((swift_name("bad")));
+
+struct __attribute__((swift_name("bad"))) RenamedAgainInAPINotesB {
+  int field;
+};

--- a/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Modules/module.modulemap
+++ b/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module SimpleKit {
+  umbrella header "SimpleKit.h"
+  export *
+  module * { export * }
+}

--- a/test/APINotes/types.m
+++ b/test/APINotes/types.m
@@ -1,7 +1,12 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -verify
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -fdisable-module-hash -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -verify
+// RUN: %clang_cc1 -ast-print %t/ModulesCache/SimpleKit.pcm | FileCheck %s
 
 #import <SomeKit/SomeKit.h>
+#import <SimpleKit/SimpleKit.h>
+
+// CHECK: struct __attribute__((swift_name("SuccessfullyRenamedA"))) RenamedAgainInAPINotesA {
+// CHECK: struct __attribute__((swift_name("SuccessfullyRenamedB"))) RenamedAgainInAPINotesB {
 
 void test(OverriddenTypes *overridden) {
   int *ip1 = global_int_ptr; // expected-warning{{incompatible pointer types initializing 'int *' with an expression of type 'double (*)(int, int)'}}


### PR DESCRIPTION
There are two reasons for this:

- It doesn't really seem appropriate for forward-declared structs to pick up attributes.

- In a proper definition `struct X { ... }`, the first `struct X` counts as a declaration, which means the API note attributes can get added ahead of time. Later on, when we try to add them *again,* they'll replace the attribute added at the first point rather than whatever the user wrote in source after the close brace. This also applies if there are any forward declarations before the definition.

There is a downside: API notes now can't affect tag types that are *never* defined (for example, structs that are forward-declared for use in pointers). Any annotations one might want to apply to such a type must be written in source. We don't seem to have any such types in the API notes today, though (tested using the swift-api-digester).

rdar://problem/29981732