### PR TITLE
[LaxConversions] Revert lax vector changes causing regressions

### DIFF
--- a/test/CodeGen/vector.c
+++ b/test/CodeGen/vector.c
@@ -60,23 +60,3 @@ void extractinttypes() {
   extern __typeof(_mm_extract_epi16(_mm_setzero_si128(), 3)) check_result_int;
   extern __typeof(_mm_extract_epi32(_mm_setzero_si128(), 3)) check_result_int;
 }
-
-// Test some logic around our lax vector comparison rules with integers.
-
-typedef int vec_int1 __attribute__((vector_size(4)));
-vec_int1 lax_vector_compare1(int x, vec_int1 y) {
-  y = x == y;
-  return y;
-}
-
-// CHECK: define i32 @lax_vector_compare1(i32 {{.*}}, i32 {{.*}})
-// CHECK: icmp eq <1 x i32>
-
-typedef int vec_int2 __attribute__((vector_size(8)));
-vec_int2 lax_vector_compare2(long long x, vec_int2 y) {
-  y = x == y;
-  return y;
-}
-
-// CHECK: define void @lax_vector_compare2(<2 x i32>* {{.*sret.*}}, i64 {{.*}}, i64 {{.*}})
-// CHECK: icmp eq <2 x i32>

--- a/test/Sema/vector-cast.c
+++ b/test/Sema/vector-cast.c
@@ -45,24 +45,12 @@ void f3(t3 Y) {
 }
 
 typedef float float2 __attribute__ ((vector_size (8)));
-typedef __attribute__((vector_size(8))) double float64x1_t;
-typedef __attribute__((vector_size(16))) double float64x2_t;
-float64x1_t vget_low_f64(float64x2_t __p0);
 
 void f4() {
   float2 f2;
-  double d, a, b, c;
-  float64x2_t v = {0.0, 1.0};
-  // FIXME: These diagnostics are inaccurate: should complain that 'double' to vector 'float2' involves truncation
-  f2 += d; // expected-error {{cannot convert between vector values of different size ('float2' (vector of 2 'float' values) and 'double')}}
-  d += f2; // expected-error {{cannot convert between vector values of different size}}
-  a = 3.0 + vget_low_f64(v);
-  b = vget_low_f64(v) + 3.0;
-  c = vget_low_f64(v);
-  c -= vget_low_f64(v);
-  // LAX conversions between scalar and vector types require same size and one element sized vectors.
-  d = f2; // expected-error {{assigning to 'double' from incompatible type 'float2'}}
-  d = d + f2; // expected-error {{assigning to 'double' from incompatible type 'float2'}}
+  double d;
+  f2 += d;
+  d += f2;
 }
 
 // rdar://15931426

--- a/test/Sema/vector-compound-assign-lax.cpp
+++ b/test/Sema/vector-compound-assign-lax.cpp
@@ -1,0 +1,45 @@
+// RUN: %clang_cc1 -ffreestanding -triple armv7 -target-feature +neon -fsyntax-only %s -verify -Wvector-conversion -DNEON
+// RUN: %clang_cc1 -ffreestanding -triple=x86_64-apple-darwin -target-feature +sse2 -fsyntax-only %s -verify -Wvector-conversion -DSSE2
+
+// Test that there are no diagnostics for vector compound assignments where we
+// support lax conversions from the RHS type to the LHS type. For context, see:
+//
+//   <rdar://problem/30112602> cannot convert between vector values ...
+//   <rdar://problem/28639522> Cannot create binary operator with two ...
+//   <rdar://problem/30110333> Invalid conversion from int64x2 to uint32x4 ...
+
+// expected-no-diagnostics
+
+#include <stdint.h>
+
+typedef int v_int32x4_t __attribute__((__vector_size__(16)));
+typedef unsigned v_uint32x4_t __attribute__((__vector_size__(16)));
+
+#ifdef NEON
+typedef __attribute__((neon_vector_type(8))) int16_t n_int16x8_t;
+typedef __attribute__((neon_vector_type(8))) uint16_t n_uint16x8_t;
+
+void fn1() {
+  n_int16x8_t i;
+  n_uint16x8_t u;
+  i += u;
+}
+#endif
+
+void fn2() {
+  v_int32x4_t i;
+  v_uint32x4_t u;
+  i += u;
+}
+
+#ifdef SSE2
+#include <x86intrin.h>
+
+typedef __attribute__((__ext_vector_type__(4))) unsigned int ev_uint32x4_t;
+
+void fn3() {
+  __m128i i;
+  ev_uint32x4_t u;
+  i += u; // FIXME: Converting uint32x4 to int64x2 should *not* be allowed.
+}
+#endif


### PR DESCRIPTION
Unspecified use of vector operations in C/C++ code support by clang
changed in the following reverted commits:

Revert "[Sema] Support lax conversions for compound assignments"
This reverts commit d8f1983628147daca298a7fe66e886c5c2580506.

Revert "[SemaExpr] Support assignments from vector to scalars with same size"
This reverts commit b8689ee716d893209ae58d29fd5a7ea372f3be8e.

Revert "In vector comparisons, handle scalar LHS just as we handle scalar RHS"
This reverts commit afcfb9e427b856a8a554417cd83e77e7ed1fe241.

rdar://problem/28610561
rdar://problem/28611139
(cherry picked from commit e025fded6ccb269b01b89bb0806eedb1fc119673)

See additionally:
rdar://problem/30112602 and rdar://problem/30111088

Conflicts:
	test/CodeGen/vector.c