### PR TITLE
[Swift SE-0160] Add swift_objc_members attribute and SwiftObjCMembers API notes

### DIFF
--- a/include/clang/APINotes/Types.h
+++ b/include/clang/APINotes/Types.h
@@ -215,6 +215,9 @@ class ObjCContextInfo : public CommonTypeInfo {
   unsigned SwiftImportAsNonGenericSpecified : 1;
   unsigned SwiftImportAsNonGeneric : 1;
 
+  unsigned SwiftObjCMembersSpecified : 1;
+  unsigned SwiftObjCMembers : 1;
+
 public:
   ObjCContextInfo()
     : CommonTypeInfo(),
@@ -222,7 +225,9 @@ public:
       DefaultNullability(0),
       HasDesignatedInits(0),
       SwiftImportAsNonGenericSpecified(false),
-      SwiftImportAsNonGeneric(false)
+      SwiftImportAsNonGeneric(false),
+      SwiftObjCMembersSpecified(false),
+      SwiftObjCMembers(false)
   { }
 
   /// Determine the default nullability for properties and methods of this
@@ -260,6 +265,16 @@ public:
     }
   }
 
+  Optional<bool> getSwiftObjCMembers() const {
+    if (SwiftObjCMembersSpecified)
+      return SwiftObjCMembers;
+    return None;
+  }
+  void setSwiftObjCMembers(Optional<bool> value) {
+    SwiftObjCMembersSpecified = value.hasValue();
+    SwiftObjCMembers = value.hasValue() ? *value : false;
+  }
+
   /// Strip off any information within the class information structure that is
   /// module-local, such as 'audited' flags.
   void stripModuleLocalInfo() {
@@ -271,7 +286,9 @@ public:
     return static_cast<const CommonTypeInfo &>(lhs) == rhs &&
            lhs.getDefaultNullability() == rhs.getDefaultNullability() &&
            lhs.HasDesignatedInits == rhs.HasDesignatedInits &&
-           lhs.getSwiftImportAsNonGeneric() == rhs.getSwiftImportAsNonGeneric();
+           lhs.getSwiftImportAsNonGeneric() ==
+             rhs.getSwiftImportAsNonGeneric() &&
+           lhs.getSwiftObjCMembers() == rhs.getSwiftObjCMembers();
   }
 
   friend bool operator!=(const ObjCContextInfo &lhs, const ObjCContextInfo &rhs) {
@@ -294,6 +311,11 @@ public:
         rhs.SwiftImportAsNonGenericSpecified) {
       lhs.SwiftImportAsNonGenericSpecified = true;
       lhs.SwiftImportAsNonGeneric = rhs.SwiftImportAsNonGeneric;
+    }
+
+    if (!lhs.SwiftObjCMembersSpecified && rhs.SwiftObjCMembersSpecified) {
+      lhs.SwiftObjCMembersSpecified = true;
+      lhs.SwiftObjCMembers = rhs.SwiftObjCMembers;
     }
 
     lhs.HasDesignatedInits |= rhs.HasDesignatedInits;

--- a/include/clang/Basic/Attr.td
+++ b/include/clang/Basic/Attr.td
@@ -1473,6 +1473,12 @@ def SwiftBridge : Attr {
   let Documentation = [SwiftBridgeDocs];
 }
 
+def SwiftObjCMembers : Attr {
+  let Spellings = [GNU<"swift_objc_members">];
+  let Subjects = SubjectList<[ObjCInterface], ErrorDiag>;
+  let Documentation = [SwiftObjCMembersDocs];
+}
+
 def SwiftError : InheritableAttr {
   let Spellings = [GCC<"swift_error">];
   let Args = [EnumArgument<"Convention", "ConventionKind",

--- a/include/clang/Basic/AttrDocs.td
+++ b/include/clang/Basic/AttrDocs.td
@@ -2449,6 +2449,13 @@ The ``swift_bridge`` attribute indicates that the type to which the attribute ap
   }];
 }
 
+def SwiftObjCMembersDocs : Documentation {
+  let Category = SwiftDocs;
+  let Content = [{
+The ``swift_objc_members`` attribute maps to the Swift ``@objcMembers`` attribute, which indicates that Swift members of this class, its subclasses, and all of the extensions thereof, will implicitly be exposed back to Objective-C.
+  }];
+}
+
 def SwiftErrorDocs : Documentation {
   let Category = SwiftDocs;
   let Heading = "swift_error";

--- a/lib/APINotes/APINotesFormat.h
+++ b/lib/APINotes/APINotesFormat.h
@@ -36,7 +36,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// API notes file minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t VERSION_MINOR = 22;  // SwiftImportAsNonGeneric
+const uint16_t VERSION_MINOR = 23;  // SwiftObjCMembers
 
 using IdentifierID = PointerEmbeddedInt<unsigned, 31>;
 using IdentifierIDField = BCVBR<16>;

--- a/lib/APINotes/APINotesReader.cpp
+++ b/lib/APINotes/APINotesReader.cpp
@@ -256,6 +256,10 @@ namespace {
       payload >>= 3;
 
       if (payload & (1 << 1))
+        info.setSwiftObjCMembers(payload & 1);
+      payload >>= 2;
+
+      if (payload & (1 << 1))
         info.setSwiftImportAsNonGeneric(payload & 1);
 
       return info;

--- a/lib/APINotes/APINotesWriter.cpp
+++ b/lib/APINotes/APINotesWriter.cpp
@@ -587,6 +587,10 @@ namespace {
       if (auto swiftImportAsNonGeneric = info.getSwiftImportAsNonGeneric()) {
         payload |= (0x01 << 1) | swiftImportAsNonGeneric.getValue();
       }
+      payload <<= 2;
+      if (auto swiftObjCMembers = info.getSwiftObjCMembers()) {
+        payload |= (0x01 << 1) | swiftObjCMembers.getValue();
+      }
       payload <<= 3;
       if (auto nullable = info.getDefaultNullability()) {
         payload |= (0x01 << 2) | static_cast<uint8_t>(*nullable);

--- a/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -217,6 +217,7 @@ namespace {
     Optional<StringRef> SwiftBridge;
     Optional<StringRef> NSErrorDomain;
     Optional<bool> SwiftImportAsNonGeneric;
+    Optional<bool> SwiftObjCMembers;
     MethodsSeq Methods;
     PropertiesSeq Properties;
   };
@@ -447,6 +448,7 @@ namespace llvm {
         io.mapOptional("SwiftBridge",           c.SwiftBridge);
         io.mapOptional("NSErrorDomain",         c.NSErrorDomain);
         io.mapOptional("SwiftImportAsNonGeneric", c.SwiftImportAsNonGeneric);
+        io.mapOptional("SwiftObjCMembers",      c.SwiftObjCMembers);
         io.mapOptional("Methods",               c.Methods);
         io.mapOptional("Properties",            c.Properties);
       }
@@ -756,6 +758,8 @@ namespace {
         cInfo.setDefaultNullability(*DefaultNullability);
       if (cl.SwiftImportAsNonGeneric)
         cInfo.setSwiftImportAsNonGeneric(*cl.SwiftImportAsNonGeneric);
+      if (cl.SwiftObjCMembers)
+        cInfo.setSwiftObjCMembers(*cl.SwiftObjCMembers);
 
       ContextID clID = Writer->addObjCContext(cl.Name, isClass, cInfo,
                                               swiftVersion);
@@ -1106,6 +1110,7 @@ namespace {
 
       handleCommonType(record, info);
       record.SwiftImportAsNonGeneric = info.getSwiftImportAsNonGeneric();
+      record.SwiftObjCMembers = info.getSwiftObjCMembers();
 
       if (info.getDefaultNullability()) {
         record.AuditedForNullability = true;

--- a/lib/Sema/SemaAPINotes.cpp
+++ b/lib/Sema/SemaAPINotes.cpp
@@ -610,6 +610,13 @@ static void ProcessAPINotes(Sema &S, ObjCInterfaceDecl *D,
     });
   }
 
+    if (auto objcMembers = info.getSwiftObjCMembers()) {
+    handleAPINotedAttribute<SwiftObjCMembersAttr>(S, D, *objcMembers,
+                                                         metadata, [&] {
+      return SwiftObjCMembersAttr::CreateImplicit(S.Context);
+    });
+  }
+
   // Handle information common to Objective-C classes and protocols.
   ProcessAPINotes(S, static_cast<clang::ObjCContainerDecl *>(D), info,
                   metadata);

--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -6794,6 +6794,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case AttributeList::AT_SwiftBridge:
     handleSwiftBridgeAttr(S, D, Attr);
     break;
+  case AttributeList::AT_SwiftObjCMembers:
+    handleSimpleAttribute<SwiftObjCMembersAttr>(S, D, Attr);
+    break;
   case AttributeList::AT_SwiftNewtype:
     handleSwiftNewtypeAttr(S, D, Attr);
     break;

--- a/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.apinotes
@@ -1,6 +1,7 @@
 Name: VersionedKit
 Classes:
   - Name: TestProperties
+    SwiftObjCMembers: true
     Properties:
       - Name: accessorsOnly
         PropertyKind:    Instance
@@ -22,6 +23,7 @@ SwiftVersions:
       - Name: TestGenericDUMP
         SwiftImportAsNonGeneric: true
       - Name: TestProperties
+        SwiftObjCMembers: false
         Properties:
           - Name: accessorsOnlyInVersion3
             PropertyKind:    Instance

--- a/test/APINotes/Inputs/roundtrip.apinotes
+++ b/test/APINotes/Inputs/roundtrip.apinotes
@@ -10,6 +10,7 @@ Classes:
     SwiftPrivate:    false
     SwiftName:       ''
     SwiftImportAsNonGeneric: true
+    SwiftObjCMembers: false
     Methods:         
       - Selector:        'cellWithImage:'
         MethodKind:      Class
@@ -61,6 +62,7 @@ Classes:
     SwiftPrivate:    false
     SwiftName:       ''
     SwiftBridge:     View
+    SwiftObjCMembers: true
     Methods:         
       - Selector:        'addSubview:'
         MethodKind:      Instance

--- a/test/APINotes/versioned.m
+++ b/test/APINotes/versioned.m
@@ -54,3 +54,8 @@
 // CHECK-VERSIONED: void privateFunc();
 
 // CHECK-VERSIONED: typedef double MyDoubleWrapper;
+
+// CHECK-UNVERSIONED: __attribute__((swift_objc_members)
+// CHECK-UNVERSIONED-NEXT: @interface TestProperties
+// CHECK-VERSIONED-NOT: __attribute__((swift_objc_members)
+// CHECK-VERSIONED: @interface TestProperties

--- a/test/SemaObjC/attr-swift_objc_members.m
+++ b/test/SemaObjC/attr-swift_objc_members.m
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -verify -fsyntax-only %s
+
+#if !__has_attribute(swift_objc_members)
+#  error Cannot query presence of swift_objc_members attribute.
+#endif
+
+__attribute__((swift_objc_members))
+__attribute__((objc_root_class))
+@interface A
+@end
+
+__attribute__((swift_objc_members)) // expected-error{{'swift_objc_members' attribute only applies to Objective-C interfaces}}
+@protocol P
+@end
+
+__attribute__((swift_objc_members)) // expected-error{{'swift_objc_members' attribute only applies to Objective-C interfaces}}
+extern void foo(void);


### PR DESCRIPTION
Implement the Clang-side attribute `swift_objc_members` for Objective-C interface declarations, which maps to Swift's `@objcMembers` attribute, per [SE-0160](https://github.com/apple/swift-evolution/blob/master/proposals/0160-objc-inference.md), along with a corresponding API note `SwiftObjCMembers`.