### PR TITLE
[4.0] [APINotes] Always provide an unversioned SwiftName of some kind.

### DIFF
--- a/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.apinotes
@@ -58,6 +58,10 @@ SwiftVersions:
           - Name: accessorsOnlyForClassExceptInVersion3
             PropertyKind:    Class
             SwiftImportAsAccessors: false
+      - Name: Swift3RenamedOnlyDUMP
+        SwiftName: SpecialSwift3Name
+      - Name: Swift3RenamedAlsoDUMP
+        SwiftName: SpecialSwift3Also
     Functions:
       - Name: moveToPointDUMP
         SwiftName: 'moveTo(a:b:)'

--- a/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.h
+++ b/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.h
@@ -36,6 +36,13 @@ typedef double MyDoubleWrapper __attribute__((swift_wrapper(struct)));
 - (Element)element;
 @end
 
+@interface Swift3RenamedOnlyDUMP
+@end
+
+__attribute__((swift_name("Swift4Name")))
+@interface Swift3RenamedAlsoDUMP
+@end
+
 
 enum __attribute__((flag_enum)) FlagEnum {
   FlagEnumA = 1,

--- a/test/APINotes/versioned.m
+++ b/test/APINotes/versioned.m
@@ -22,11 +22,31 @@
 // CHECK-UNVERSIONED-DUMP: SwiftNameAttr {{.+}} "moveTo(x:y:)"
 // CHECK-UNVERSIONED-DUMP-NEXT: SwiftVersionedAttr {{.+}} Implicit 3.0
 // CHECK-UNVERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} Implicit "moveTo(a:b:)"
+// CHECK-DUMP-NOT: Attr
 
 // CHECK-DUMP-LABEL: Dumping TestGenericDUMP
 // CHECK-VERSIONED-DUMP: SwiftImportAsNonGenericAttr {{.+}} Implicit
 // CHECK-UNVERSIONED-DUMP: SwiftVersionedAttr {{.+}} Implicit 3.0
 // CHECK-UNVERSIONED-DUMP-NEXT: SwiftImportAsNonGenericAttr {{.+}} Implicit
+// CHECK-DUMP-NOT: Attr
+
+// CHECK-DUMP-LABEL: Dumping Swift3RenamedOnlyDUMP
+// CHECK-DUMP: in VersionedKit Swift3RenamedOnlyDUMP
+// CHECK-VERSIONED-DUMP-NEXT: SwiftVersionedRemovalAttr {{.+}} Implicit 0 {{[0-9]+}}
+// CHECK-VERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} "SpecialSwift3Name"
+// CHECK-UNVERSIONED-DUMP-NEXT: SwiftVersionedAttr {{.+}} Implicit 3.0
+// CHECK-UNVERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} Implicit "SpecialSwift3Name"
+// CHECK-DUMP-NOT: Attr
+
+// CHECK-DUMP-LABEL: Dumping Swift3RenamedAlsoDUMP
+// CHECK-DUMP: in VersionedKit Swift3RenamedAlsoDUMP
+// CHECK-VERSIONED-DUMP-NEXT: SwiftVersionedAttr {{.+}} Implicit 0
+// CHECK-VERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} <line:{{.+}}, col:{{.+}}> "Swift4Name"
+// CHECK-VERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} "SpecialSwift3Also"
+// CHECK-UNVERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} <line:{{.+}}, col:{{.+}}> "Swift4Name"
+// CHECK-UNVERSIONED-DUMP-NEXT: SwiftVersionedAttr {{.+}} Implicit 3.0
+// CHECK-UNVERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} Implicit "SpecialSwift3Also"
+// CHECK-DUMP-NOT: Attr
 
 // CHECK-DUMP-NOT: Dumping
 


### PR DESCRIPTION
- **Explanation:** We use API notes to record whether a particular C/ObjC API has changed its name for Swift 4. However, if it had a custom name in Swift 3 and then went back to the default in Swift 4, the Swift 4 name would not be visible in Swift 3 mode. (This is a correctness issue for types, which we always import under their Swift 4 name.) This patch fixes that by explicitly recording the absence of a custom name.
- **Scope:** Fairly narrow; the situation described doesn't seem common. The Swift-side change affects the order things are printed in, but only the order.
- **Issue:** rdar://problem/31826517
- **Reviewed by:** @DougGregor (Clang-side change), @nkcsgexi (Swift helper change)
- **Risk:** Low. Does not affect non-API-notes Clang at all, and uses existing code paths on the Swift side. One minor change to the way declarations are printed in Swift is needed for consistent behavior across platforms.
- **Testing:** Added compiler regression tests, verified that the original test case now behaves as expected.