### PR TITLE
[System z]Update default CPU for s390x to support conversion between unsigned i…

### DIFF
--- a/lib/Basic/Targets.cpp
+++ b/lib/Basic/Targets.cpp
@@ -7046,7 +7046,7 @@ class SystemZTargetInfo : public TargetInfo {
 
 public:
   SystemZTargetInfo(const llvm::Triple &Triple, const TargetOptions &)
-      : TargetInfo(Triple), CPU("z10"), HasTransactionalExecution(false),
+      : TargetInfo(Triple), CPU("z196"), HasTransactionalExecution(false),
         HasVector(false) {
     IntMaxType = SignedLong;
     Int64Type = SignedLong;

--- a/lib/Driver/Tools.cpp
+++ b/lib/Driver/Tools.cpp
@@ -1947,7 +1947,7 @@ void Clang::AddSystemZTargetArgs(const ArgList &Args,
 static const char *getSystemZTargetCPU(const ArgList &Args) {
   if (const Arg *A = Args.getLastArg(options::OPT_march_EQ))
     return A->getValue();
-  return "z10";
+  return "z196";
 }
 
 static void getSystemZTargetFeatures(const ArgList &Args,


### PR DESCRIPTION
…ntegers and floating point numbers

On System z, instructions for conversion between unsigned integers and floating point numbers was added in z196.  We want to have this support by the default on Swift.  

The missing support was exposed by the test swift/validation-test/stdlib/FixedPointConversion.swift.gyb.  With this change, the test case passes on s390x.