### PR TITLE
[Modules] Include error diagnostics to the module hash

### DIFF
--- a/include/clang/Basic/LangOptions.def
+++ b/include/clang/Basic/LangOptions.def
@@ -153,6 +153,7 @@ COMPATIBLE_LANGOPT(ModulesStrictDeclUse, 1, 0, "requiring declaration of module 
 BENIGN_LANGOPT(ModulesErrorRecovery, 1, 1, "automatically importing modules as needed when performing error recovery")
 BENIGN_LANGOPT(ImplicitModules, 1, 1, "building modules that are not specified via -fmodule-file")
 COMPATIBLE_LANGOPT(ModulesLocalVisibility, 1, 0, "local submodule visibility")
+COMPATIBLE_LANGOPT(ModulesHashErrorDiags, 1, 0, "hash out diagnostic errors as part of the module hash")
 COMPATIBLE_LANGOPT(Optimize          , 1, 0, "__OPTIMIZE__ predefined macro")
 COMPATIBLE_LANGOPT(OptimizeSize      , 1, 0, "__OPTIMIZE_SIZE__ predefined macro")
 COMPATIBLE_LANGOPT(Static            , 1, 0, "__STATIC__ predefined macro (as opposed to __DYNAMIC__)")

--- a/include/clang/Driver/CC1Options.td
+++ b/include/clang/Driver/CC1Options.td
@@ -432,6 +432,8 @@ def fmodules_local_submodule_visibility :
 def fmodule_format_EQ : Joined<["-"], "fmodule-format=">,
   HelpText<"Select the container format for clang modules and PCH. "
            "Supported options are 'raw' and 'obj'.">;
+def fmodules_hash_error_diagnostics : Flag<["-"], "fmodules-hash-error-diagnostics">,
+  HelpText<"Use a separate module cache for modules compiled with conflicting -Werror options">;
 def ftest_module_file_extension_EQ :
   Joined<["-"], "ftest-module-file-extension=">,
   HelpText<"introduce a module file extension for testing purposes. "

--- a/include/clang/Frontend/CompilerInvocation.h
+++ b/include/clang/Frontend/CompilerInvocation.h
@@ -174,7 +174,7 @@ public:
   
   /// \brief Retrieve a module hash string that is suitable for uniquely 
   /// identifying the conditions under which the module was built.
-  std::string getModuleHash() const;
+  std::string getModuleHash(DiagnosticsEngine &Diags) const;
   
   /// @}
   /// @name Option Subgroups

--- a/lib/Frontend/CompilerInstance.cpp
+++ b/lib/Frontend/CompilerInstance.cpp
@@ -472,7 +472,7 @@ std::string CompilerInstance::getSpecificModuleCachePath() {
   SmallString<256> SpecificModuleCache(getHeaderSearchOpts().ModuleCachePath);
   if (!SpecificModuleCache.empty() && !getHeaderSearchOpts().DisableModuleHash)
     llvm::sys::path::append(SpecificModuleCache,
-                            getInvocation().getModuleHash());
+                            getInvocation().getModuleHash(getDiagnostics()));
   return SpecificModuleCache.str();
 }
 
@@ -1111,9 +1111,11 @@ static bool compileModuleImpl(CompilerInstance &ImportingInstance,
   PPOpts.RetainRemappedFileBuffers = true;
     
   Invocation->getDiagnosticOpts().VerifyDiagnostics = 0;
-  assert(ImportingInstance.getInvocation().getModuleHash() ==
-         Invocation->getModuleHash() && "Module hash mismatch!");
-  
+  assert(ImportingInstance.getInvocation().getModuleHash(
+             ImportingInstance.getDiagnostics()) ==
+             Invocation->getModuleHash(ImportingInstance.getDiagnostics()) &&
+         "Module hash mismatch!");
+
   // Construct a compiler instance that will be used to actually create the
   // module.  Since we're sharing a PCMCache,
   // CompilerInstance::CompilerInstance is responsible for finalizing the

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1967,6 +1967,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
       Args.hasArg(OPT_fmodules_decluse) || Opts.ModulesStrictDeclUse;
   Opts.ModulesLocalVisibility =
       Args.hasArg(OPT_fmodules_local_submodule_visibility) || Opts.ModulesTS;
+  Opts.ModulesHashErrorDiags = Args.hasArg(OPT_fmodules_hash_error_diagnostics);
   Opts.ModulesSearchAll = Opts.Modules &&
     !Args.hasArg(OPT_fno_modules_search_all) &&
     Args.hasArg(OPT_fmodules_search_all);
@@ -2535,7 +2536,16 @@ bool CompilerInvocation::CreateFromArgs(CompilerInvocation &Res,
   return Success;
 }
 
-std::string CompilerInvocation::getModuleHash() const {
+// Some extension diagnostics aren't explicitly mapped and require custom
+// logic in the dianognostic engine to be used, track -pedantic-errors
+static bool isExtHandlingFromDiagsError(DiagnosticsEngine &Diags) {
+  diag::Severity Ext = Diags.getExtensionHandlingBehavior();
+  if (Ext == diag::Severity::Warning && Diags.getWarningsAsErrors())
+    return true;
+  return Ext >= diag::Severity::Error;
+}
+
+std::string CompilerInvocation::getModuleHash(DiagnosticsEngine &Diags) const {
   // Note: For QoI reasons, the things we use as a hash here should all be
   // dumped via the -module-info flag.
   using llvm::hash_code;
@@ -2639,6 +2649,24 @@ std::string CompilerInvocation::getModuleHash() const {
       struct stat statBuf;
       if (stat(systemVersionFile.c_str(), &statBuf) == 0)
         code = hash_combine(code, statBuf.st_mtime);
+    }
+  }
+
+  // Check for a couple things (see checkDiagnosticMappings in ASTReader.cpp):
+  //  -Werror: consider all warnings into the hash
+  //  -Werror=something: consider only the specified into the hash
+  //  -pedantic-error
+  if (getLangOpts()->ModulesHashErrorDiags) {
+    bool ConsiderAllWarningsAsErrors = Diags.getWarningsAsErrors();
+    code = hash_combine(code, isExtHandlingFromDiagsError(Diags));
+    for (auto DiagIDMappingPair : Diags.getDiagnosticMappings()) {
+      diag::kind DiagID = DiagIDMappingPair.first;
+      auto CurLevel = Diags.getDiagnosticLevel(DiagID, SourceLocation());
+      if (CurLevel < DiagnosticsEngine::Error && !ConsiderAllWarningsAsErrors)
+        continue; // not significant
+      code = hash_combine(
+          code,
+          Diags.getDiagnosticIDs()->getWarningOptionForDiag(DiagID).str());
     }
   }
 

--- a/test/Modules/hash-werror.m
+++ b/test/Modules/hash-werror.m
@@ -1,0 +1,54 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+
+// (1) Test -Werror
+// RUN: echo 'int foo() { return fn(); }' > %t/foo.h
+// RUN: echo 'module foo { header "foo.h" export * }' > %t/module.modulemap
+//
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps %s -fsyntax-only \
+// RUN:   -I%t -fmodules-cache-path=%t/cache -Rmodule-build \
+// RUN:   -fmodules-hash-error-diagnostics 2>%t/out
+//
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps %s -fsyntax-only \
+// RUN:   -I%t -Werror -fmodules-cache-path=%t/cache -Rmodule-build \
+// RUN:   -Wno-implicit-function-declaration \
+// RUN:   -fmodules-hash-error-diagnostics 2>>%t/out
+
+// RUN: FileCheck --check-prefix=CHECKWERROR %s -input-file %t/out
+// CHECKWERROR: remark: building module 'foo' as '/[[PATH:.*]]/foo-
+// CHECKWERROR-NOT: remark: building module 'foo' as '/[[PATH]]/foo-
+
+// (2) Test -Werror=
+// RUN: rm -rf %t/out %t/cache
+//
+// RUN: not %clang_cc1 -fmodules -fimplicit-module-maps %s -fsyntax-only \
+// RUN:   -I%t -Werror -fmodules-cache-path=%t/cache -Rmodule-build \
+// RUN:   -fmodules-hash-error-diagnostics 2>%t/out
+//
+// RUN: not %clang_cc1 -fmodules -fimplicit-module-maps %s -fsyntax-only \
+// RUN:   -I%t -fmodules-cache-path=%t/cache -Rmodule-build \
+// RUN:   -Werror=implicit-function-declaration \
+// RUN:   -fmodules-hash-error-diagnostics 2>>%t/out
+
+// RUN: FileCheck --check-prefix=CHECKWERROREQUALS %s -input-file %t/out
+// CHECKWERROREQUALS: remark: building module 'foo' as '/[[PATH:.*]]/foo-
+// CHECKWERROREQUALS-NOT: remark: building module 'foo' as '/[[PATH]]/foo-
+
+// (3) Test -pedantic-errors
+// RUN: rm -rf %t/out %t/cache
+// RUN: echo '#ifdef foo' > %t/foo.h
+// RUN: echo '#endif bad // extension!' >> %t/foo.h
+
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps %s -fsyntax-only \
+// RUN:   -I%t -fmodules-cache-path=%t/cache -Rmodule-build -x c \
+// RUN:   -fmodules-hash-error-diagnostics 2>%t/out
+//
+// RUN: not %clang_cc1 -fmodules -fimplicit-module-maps %s -fsyntax-only \
+// RUN:   -I%t -pedantic-errors -fmodules-cache-path=%t/cache -Rmodule-build -x c \
+// RUN:   -fmodules-hash-error-diagnostics 2>>%t/out
+
+// RUN: FileCheck --check-prefix=CHECKPEDANTICERROR %s -input-file %t/out
+// CHECKPEDANTICERROR: remark: building module 'foo' as '/[[PATH:.*]]/foo-
+// CHECKPEDANTICERROR-NOT: remark: building module 'foo' as '/[[PATH]]/foo-
+
+#include "foo.h"


### PR DESCRIPTION
Add a CC1 option to include error diagnostics to the module hash:
-fmodules-hash-error-diagnostics

rdar://problem/31796394