### PR TITLE
[refactor] Improve refactoring in macro arguments

### DIFF
--- a/lib/Edit/FillInMissingSwitchEnumCases.cpp
+++ b/lib/Edit/FillInMissingSwitchEnumCases.cpp
@@ -136,7 +136,8 @@ void edit::fillInMissingSwitchEnumCases(
           else
             InsertionLoc = Switch->getBody()->getLocEnd();
         }
-        Consumer(FixItHint::CreateInsertion(InsertionLoc, OS.str()));
+        Consumer(FixItHint::CreateInsertion(
+            Context.getSourceManager().getSpellingLoc(InsertionLoc), OS.str()));
       };
 
   // Determine which enum cases are uncovered.

--- a/lib/Tooling/Refactor/LocalizeObjCStringLiteral.cpp
+++ b/lib/Tooling/Refactor/LocalizeObjCStringLiteral.cpp
@@ -69,11 +69,15 @@ LocalizeObjCStringLiteralOperation::perform(ASTContext &Context,
                                             const RefactoringOptionSet &Options,
                                             unsigned SelectedCandidateIndex) {
   std::vector<RefactoringReplacement> Replacements;
-  SourceLocation LocStart = E->getLocStart();
+  // TODO: New API: Replace by something like Node.wrap("NSLocalizedString(", ",
+  // @""")
+  SourceLocation LocStart =
+      Context.getSourceManager().getSpellingLoc(E->getLocStart());
   Replacements.emplace_back(SourceRange(LocStart, LocStart),
                             StringRef("NSLocalizedString("));
   SourceLocation LocEnd = getPreciseTokenLocEnd(
-      E->getLocEnd(), Context.getSourceManager(), Context.getLangOpts());
+      Context.getSourceManager().getSpellingLoc(E->getLocEnd()),
+      Context.getSourceManager(), Context.getLangOpts());
   Replacements.emplace_back(SourceRange(LocEnd, LocEnd), StringRef(", @\"\")"));
   return std::move(Replacements);
 }

--- a/test/Refactor/ExtractRepeatedExpression/extract-repeated-expr-initiate.m
+++ b/test/Refactor/ExtractRepeatedExpression/extract-repeated-expr-initiate.m
@@ -92,3 +92,15 @@ void implicitPropertyWithoutGetter(ImplicitPropertyWithoutGetter *x) {
 }
 
 // RUN: not clang-refactor-test initiate -action extract-repeated-expr-into-var -at=%s:90:3 %s 2>&1 | FileCheck --check-prefix=CHECK-NO %s
+
+// Prohibit ininiation in macros:
+
+#define MACROREF(X) X.object
+
+void prohibitMacroExpr(Wrapper *wrapper) {
+  // macro-prohibited: +1:3
+  wrapper.object.prop = 0;
+  MACROREF(wrapper).prop = 1;
+}
+
+// RUN: not clang-refactor-test initiate -action extract-repeated-expr-into-var -at=macro-prohibited %s 2>&1 | FileCheck --check-prefix=CHECK-NO %s

--- a/test/Refactor/ExtractRepeatedExpression/extract-repeated-expr-perform.m
+++ b/test/Refactor/ExtractRepeatedExpression/extract-repeated-expr-perform.m
@@ -78,3 +78,21 @@ void worksOnClassProperty() {
 // CHECK5-NEXT: "classObject" [[@LINE-4]]:3 -> [[@LINE-4]]:22
 
 // RUN: clang-refactor-test perform -action extract-repeated-expr-into-var -at=%s:73:3 %s | FileCheck --check-prefix=CHECK5 %s
+
+#define MACROARG1(X, Y) (X)
+#define MACROARG2(X) X; ref.object.prop = 0
+
+void macroArgument(Wrapper *ref) {
+  // macro-arg1: +1:13
+  MACROARG1(Wrapper.classObject->ivar, 1); // MACRO-ARG1: "Object *classObject = Wrapper.classObject;\n" [[@LINE]]:3 -> [[@LINE]]:3
+                                             // MACRO-ARG1: "classObject" [[@LINE-1]]:13 -> [[@LINE-1]]:32
+  MACROARG1(Wrapper.classObject.prop, 0) = 0;// MACRO-ARG1: "classObject" [[@LINE]]:13 -> [[@LINE]]:32
+
+  // macro-arg2: +3:13
+  MACROARG2(int x = 0; ref.object->ivar); // MACRO-ARG2: "Object *object = ref.object;\n" [[@LINE]]:3 -> [[@LINE]]:3
+                                          // MACRO-ARG2-NEXT: "object" [[@LINE-1]]:24 -> [[@LINE-1]]:34
+  MACROARG2(ref.object.prop);// MARO-ARG2-NEXT: "object" [[@LINE]]:13 -> [[@LINE]]:23
+}
+
+// RUN: clang-refactor-test perform -action extract-repeated-expr-into-var -at=macro-arg1 %s | FileCheck --check-prefix=MACRO-ARG1 %s
+// RUN: clang-refactor-test perform -action extract-repeated-expr-into-var -at=macro-arg2 %s | FileCheck --check-prefix=MACRO-ARG2 %s

--- a/test/Refactor/FillInEnumSwitchCases/fill-in-cases-perform.cpp
+++ b/test/Refactor/FillInEnumSwitchCases/fill-in-cases-perform.cpp
@@ -78,3 +78,16 @@ void perform1(PREFIX Color c) {
 // RUN: clang-refactor-test perform -action fill-in-enum-switch-cases -at=%s:43:3 %s -std=c++11 -D NESTED1 -D NESTED1NS -D ENUMCLASS | FileCheck --check-prefix=CHECK6 %s
 // RUN: clang-refactor-test perform -action fill-in-enum-switch-cases -at=%s:43:3 -at=%s:54:3 -at=%s:63:3 %s -std=c++11 -D NESTEDANON | FileCheck --check-prefix=CHECK1 %s
 // RUN: clang-refactor-test perform -action fill-in-enum-switch-cases -at=%s:43:3 -at=%s:54:3 -at=%s:63:3 %s -std=c++11 -D NESTEDANON -D ENUMCLASS | FileCheck --check-prefix=CHECK2 %s
+
+#define MACROARG(X) X
+
+void macroArg(PREFIX Color c) {
+  // macro-arg: +2:12
+  // macro-arg-range-begin: +1:12
+  MACROARG(switch (c) {
+  }); // MACRO-ARG: "case Black:\n<#code#>\nbreak;\ncase Blue:\n<#code#>\nbreak;\ncase White:\n<#code#>\nbreak;\ncase Gold:\n<#code#>\nbreak;\n" [[@LINE]]
+  // macro-arg-range-end: -1:4
+}
+
+// RUN: clang-refactor-test perform -action fill-in-enum-switch-cases -at=macro-arg %s | FileCheck --check-prefix=MACRO-ARG %s
+// RUN: clang-refactor-test perform -action fill-in-enum-switch-cases -selected=macro-arg-range %s | FileCheck --check-prefix=MACRO-ARG %s

--- a/test/Refactor/IfSwitchConversion/if-switch-conversion-perform.cpp
+++ b/test/Refactor/IfSwitchConversion/if-switch-conversion-perform.cpp
@@ -305,3 +305,17 @@ void noBracesNeeded(int x) {
 }
 
 // RUN: clang-refactor-test perform -action if-switch-conversion -at=%s:253:3 -at=%s:269:3 -at=%s:275:3 -at=%s:288:3 -at=%s:295:3 %s | FileCheck --check-prefix=CHECK8 %s
+
+#define MACRO(X) X
+
+void macroArg(int x) {
+  // macro-arg: +1:9
+  MACRO(if (x == 2) { // MACRO-ARG: "switch (" [[@LINE]]:9 -> [[@LINE]]:13
+    ;                 // MACRO-ARG: ") {\ncase " [[@LINE-1]]:14 -> [[@LINE-1]]:18
+                      // MACRO-ARG: ":" [[@LINE-2]]:19 -> [[@LINE-2]]:22
+  } else if (x == 3) { // MACRO-ARG: "break;\ncase " [[@LINE]]:3 -> [[@LINE]]:19
+    ;                 // MACRO-ARG: ":" [[@LINE-1]]:20 -> [[@LINE-1]]:23
+  }); // MACRO-ARG: "break;\n" [[@LINE]]:3 -> [[@LINE]]:3
+}
+
+// RUN: clang-refactor-test perform -action if-switch-conversion -at=macro-arg %s | FileCheck --check-prefix=MACRO-ARG %s

--- a/test/Refactor/LocalizeObjCStringLiteral/localize-objc-perform.m
+++ b/test/Refactor/LocalizeObjCStringLiteral/localize-objc-perform.m
@@ -7,3 +7,14 @@ void perform() {
 // CHECK1-NEXT: ", @"")" [[@LINE-3]]:30 -> [[@LINE-3]]:30
 // RUN: clang-refactor-test perform -action localize-objc-string-literal -at=%s:4:22 %s | FileCheck --check-prefix=CHECK1 %s
 // RUN: clang-refactor-test perform -action localize-objc-string-literal -selected=%s:4:23-4:30 %s | FileCheck --check-prefix=CHECK1 %s
+
+#define MACRO(x, y) x
+
+void performInMacroArgument() {
+  // macro-arg: +2:9
+  // macro-arg-range-begin: +1:9
+  MACRO(@"hello", 1);           // CHECK2: "NSLocalizedString(" [[@LINE]]:9 -> [[@LINE]]:9
+  // macro-arg-range-end: -1:17 // CHECK2: ", @"")" [[@LINE-1]]:17 -> [[@LINE-1]]:17
+}
+// RUN: clang-refactor-test perform -action localize-objc-string-literal -at=macro-arg %s | FileCheck --check-prefix=CHECK2 %s
+// RUN: clang-refactor-test perform -action localize-objc-string-literal -selected=macro-arg-range %s | FileCheck --check-prefix=CHECK2 %s

--- a/tools/libclang/CRefactor.cpp
+++ b/tools/libclang/CRefactor.cpp
@@ -859,6 +859,7 @@ public:
       SourceLocation Loc = Replacement.value().Range.getBegin();
       const std::pair<FileID, unsigned> DecomposedLocation =
           SM.getDecomposedLoc(Loc);
+      assert(DecomposedLocation.first.isValid() && "Invalid file!");
       const FileEntry *Entry = SM.getFileEntryForID(DecomposedLocation.first);
       FilesToReplacements.try_emplace(Entry, std::vector<unsigned>())
           .first->second.push_back(Replacement.index());


### PR DESCRIPTION
This PR fixes issues that occurred when refactoring in macro arguments for the following actions:
- Extract repeated expression.
- NSLocalizedString wrap.
- Convert if to switch.
- Fill in missing switch cases.