### PR TITLE
[refactor] Fix a crash that happens when generating a "Add Missing Switch Cases" fixit while parsing an incomplete switch

### DIFF
--- a/lib/Edit/FillInMissingSwitchEnumCases.cpp
+++ b/lib/Edit/FillInMissingSwitchEnumCases.cpp
@@ -49,6 +49,8 @@ bool useBraces(const SwitchStmt *S) {
   unsigned CaseCount = 0, CompoundCasesCount = 0;
   for (const SwitchCase *Case = S->getSwitchCaseList(); Case;
        Case = Case->getNextSwitchCase(), ++CaseCount) {
+    if (!Case->getSubStmt())
+      continue;
     if (isa<CompoundStmt>(Case->getSubStmt()))
       ++CompoundCasesCount;
   }

--- a/test/FixIt/fixit-fill-in-switch-crash.cpp
+++ b/test/FixIt/fixit-fill-in-switch-crash.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -verify -std=c++11 %s
+// RUN: not %clang_cc1 -fdiagnostics-parseable-fixits -std=c++11 %s 2>&1 | FileCheck %s
+
+enum Color {
+  Black, Red
+};
+
+void dontCrashOnEmptySubStmt(Color c) { // expected-note {{to match this '{'}}
+  switch (c) { // expected-note {{to match this '{'}} \
+               // expected-warning {{enumeration value 'Red' not handled in switch}} \
+               // expected-note {{add missing switch cases}}
+  case Black: // CHECK: fix-it:{{.*}}:{[[@LINE+3]]:10-[[@LINE+3]]:10}:"case Red:\n<#code#>\nbreak;\n"
+  // expected-error@+2 {{expected expression}}
+  // expected-error@+1 2 {{expected '}'}}
+  case //


### PR DESCRIPTION
rdar://32854328