### PR TITLE
[refactor] "Fill in abstract methods" should not place method groups after an  implicit method that overrides a method in the abstract class

### DIFF
--- a/lib/Tooling/Refactor/FillInMissingMethodStubsFromAbstractClasses.cpp
+++ b/lib/Tooling/Refactor/FillInMissingMethodStubsFromAbstractClasses.cpp
@@ -156,7 +156,7 @@ static SourceLocation findInsertionLocationForMethodsFromAbstractClass(
     const SourceManager &SM, const LangOptions &LangOpts) {
   SourceLocation Loc;
   for (const CXXMethodDecl *M : Class->methods()) {
-    if (!M->isVirtual() || M->isPure())
+    if (!M->isVirtual() || M->isPure() || M->isImplicit())
       continue;
     for (const CXXMethodDecl *OM : M->overridden_methods()) {
       OM = OM->getCanonicalDecl();

--- a/test/Refactor/FillInMissingMethodStubsFromAbstractClasses/fill-in-missing-abstract-methods-perform.cpp
+++ b/test/Refactor/FillInMissingMethodStubsFromAbstractClasses/fill-in-missing-abstract-methods-perform.cpp
@@ -99,3 +99,28 @@ struct GenericSubType : GenericType<int> {
 // CHECK8: "void firstMethod(int x, int y) override;\n\nvoid thirdMethod(int a) override;\n\nvoid fourthMethod() override;\n\n" [[@LINE-1]]:1
 
 // RUN: clang-refactor-test perform -action fill-in-missing-abstract-methods -at=%s:91:1 -at=%s:96:1 %s | FileCheck --check-prefix=CHECK8 %s
+
+
+struct BaseClass2
+{
+    virtual ~BaseClass2();
+    virtual int load() = 0;
+};
+
+// correct-implicit-destructor-placement: +1:1
+struct DerivedImplicitDestructorClass2
+: public BaseClass2
+{
+
+}; // CHECK-DESTRUCTOR: "int load() override;\n\n" [[@LINE]]:1
+
+// Don't insert methods after the destructor:
+// correct-destructor-placement: +1:1
+struct DerivedExplicitDestructorClass2
+: public BaseClass2 {
+  ~DerivedImplicitDestructorClass2();
+
+
+}; // CHECK-DESTRUCTOR: "int load() override;\n\n" [[@LINE]]:1
+
+// RUN: clang-refactor-test perform -action fill-in-missing-abstract-methods -at=correct-implicit-destructor-placement -at=correct-destructor-placement %s | FileCheck --check-prefix=CHECK-DESTRUCTOR %s


### PR DESCRIPTION
This commit fixes an issue where the refactoring action "Fill in abstract methods"
inserted method declarations outside of the class body because Clang decided to
place them after the implicit destructor.

rdar://32857076