### PR TITLE
[refactor] Add "Extract Expression" action 

### DIFF
--- a/include/clang-c/Refactor.h
+++ b/include/clang-c/Refactor.h
@@ -156,6 +156,12 @@ enum CXRefactoringActionType {
   * declarations without respective definitions.
   */
   CXRefactor_ImplementDeclaredMethods = 10,
+
+  /**
+   * \brief The sub-action of 'extract' that extracts source expression into a
+   * new variable.
+   */
+  CXRefactor_Extract_Expression = 11,
 };
 
 /**

--- a/include/clang/Tooling/Refactor/RefactoringActions.def
+++ b/include/clang/Tooling/Refactor/RefactoringActions.def
@@ -32,6 +32,8 @@ REFACTORING_SUB_ACTION(Local, Rename, "Rename")
 REFACTORING_OPERATION_ACTION(Extract, "Extract Function", "extract")
 REFACTORING_OPERATION_SUB_ACTION(Method, Extract, "Extract Method",
                                  "extract-method")
+REFACTORING_OPERATION_SUB_ACTION(Expression, Extract, "Extract Expression",
+                                 "extract-expression")
 
 REFACTORING_OPERATION_ACTION(IfSwitchConversion, "Convert to Switch",
                              "if-switch-conversion")

--- a/lib/Tooling/Refactor/CMakeLists.txt
+++ b/lib/Tooling/Refactor/CMakeLists.txt
@@ -5,6 +5,7 @@ add_clang_library(clangToolingRefactor
   ASTStateSerialization.cpp
   Extract.cpp
   ExtractRepeatedExpressionIntoVariable.cpp
+  ExtractionUtils.cpp
   FillInEnumSwitchCases.cpp
   FillInMissingMethodStubsFromAbstractClasses.cpp
   FillInMissingProtocolStubs.cpp

--- a/lib/Tooling/Refactor/Extract.cpp
+++ b/lib/Tooling/Refactor/Extract.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "ExtractionUtils.h"
 #include "RefactoringOperations.h"
 #include "SourceLocationUtilities.h"
 #include "StmtUtils.h"
@@ -56,6 +57,8 @@ struct CompoundStatementRange {
   CompoundStmt::const_body_iterator end() const { return Last + 1; }
 };
 
+enum class ExtractionKind { Function, Method, Expression };
+
 class ExtractOperation : public RefactoringOperation {
 public:
   struct CandidateInfo {
@@ -80,12 +83,11 @@ public:
                    std::vector<std::string> Candidates,
                    Optional<CompoundStatementRange> ExtractedStmtRange,
                    Optional<CandidateInfo> FirstCandidateInfo,
-                   bool IsMethodExtraction)
+                   ExtractionKind Kind)
       : S(S), ParentStmt(ParentStmt),
         FunctionLikeParentDecl(FunctionLikeParentDecl),
         Candidates(std::move(Candidates)),
-        ExtractedStmtRange(ExtractedStmtRange),
-        IsMethodExtraction(IsMethodExtraction) {
+        ExtractedStmtRange(ExtractedStmtRange), Kind(Kind) {
     if (FirstCandidateInfo)
       CandidateExtractionInfo.push_back(*FirstCandidateInfo);
   }
@@ -107,15 +109,27 @@ public:
   }
 
   std::vector<RefactoringActionType> getAvailableSubActions() override {
+    std::vector<RefactoringActionType> SubActions;
     if (isa<CXXMethodDecl>(FunctionLikeParentDecl) ||
         isa<ObjCMethodDecl>(FunctionLikeParentDecl))
-      return {RefactoringActionType::Extract_Method};
-    return {};
+      SubActions.push_back(RefactoringActionType::Extract_Method);
+    if (isLexicalExpression(S, ParentStmt))
+      SubActions.push_back(RefactoringActionType::Extract_Expression);
+    return SubActions;
+  }
+
+  bool isMethodExtraction() const { return Kind == ExtractionKind::Method; }
+
+  bool isExpressionExtraction() const {
+    return Kind == ExtractionKind::Expression;
   }
 
   llvm::Expected<RefactoringResult> perform(ASTContext &Context, const Preprocessor &ThePreprocessor,
           const RefactoringOptionSet &Options,
           unsigned SelectedCandidateIndex) override;
+
+  llvm::Expected<RefactoringResult>
+  performExpressionExtraction(ASTContext &Context, PrintingPolicy &PP);
 
   const Stmt *S, *ParentStmt;
   const Decl *FunctionLikeParentDecl;
@@ -123,7 +137,7 @@ public:
   /// A set of extraction candidates that correspond to the extracted code.
   SmallVector<CandidateInfo, 2> CandidateExtractionInfo;
   Optional<CompoundStatementRange> ExtractedStmtRange;
-  bool IsMethodExtraction;
+  ExtractionKind Kind;
 };
 
 } // end anonymous namespace
@@ -167,7 +181,7 @@ static RefactoringOperationResult
 initiateAnyExtractOperation(ASTSlice &Slice, ASTContext &Context,
                             SourceLocation Location, SourceRange SelectionRange,
                             bool CreateOperation,
-                            bool IsMethodExtraction = false) {
+                            ExtractionKind Kind = ExtractionKind::Function) {
   auto SelectedStmtsOpt = Slice.getSelectedStmtSet();
   if (!SelectedStmtsOpt)
     return None;
@@ -195,6 +209,12 @@ initiateAnyExtractOperation(ASTSlice &Slice, ASTContext &Context,
     if (!PRE->isMessagingGetter())
       return RefactoringOperationResult("property setter can't be extracted");
   }
+
+  const Stmt *ParentStmt =
+      Slice.parentStmtForIndex(*Stmts.containsSelectionRangeIndex);
+  if (Kind == ExtractionKind::Expression &&
+      !isLexicalExpression(Selected, ParentStmt))
+    return None;
 
   RefactoringOperationResult Result;
   Result.Initiated = true;
@@ -244,9 +264,8 @@ initiateAnyExtractOperation(ASTSlice &Slice, ASTContext &Context,
   }
 
   auto Operation = llvm::make_unique<ExtractOperation>(
-      Selected, Slice.parentStmtForIndex(*Stmts.containsSelectionRangeIndex),
-      ParentDecl, std::move(Candidates), ExtractedStmtRange, FirstCandidateInfo,
-      IsMethodExtraction);
+      Selected, ParentStmt, ParentDecl, std::move(Candidates),
+      ExtractedStmtRange, FirstCandidateInfo, Kind);
   auto &CandidateExtractionInfo = Operation->CandidateExtractionInfo;
   SourceRange Range;
   if (ExtractedStmtRange)
@@ -290,8 +309,16 @@ RefactoringOperationResult clang::tooling::initiateExtractMethodOperation(
     SourceRange SelectionRange, bool CreateOperation) {
   // TODO: Verify that method extraction is actually possible.
   return initiateAnyExtractOperation(Slice, Context, Location, SelectionRange,
-                                     CreateOperation,
-                                     /*IsMethodExtraction=*/true);
+                                     CreateOperation, ExtractionKind::Method);
+}
+
+RefactoringOperationResult clang::tooling::initiateExtractExpressionOperation(
+    ASTSlice &Slice, ASTContext &Context, SourceLocation Location,
+    SourceRange SelectionRange, bool CreateOperation) {
+  RefactoringOperationResult R =
+      initiateAnyExtractOperation(Slice, Context, Location, SelectionRange,
+                                  CreateOperation, ExtractionKind::Expression);
+  return R;
 }
 
 using ReferencedEntity =
@@ -1429,6 +1456,54 @@ static bool isInHeader(SourceLocation Loc, const SourceManager &SM) {
       .Default(false);
 }
 
+llvm::Expected<RefactoringResult>
+ExtractOperation::performExpressionExtraction(ASTContext &Context,
+                                              PrintingPolicy &PP) {
+  assert(isExpressionExtraction() && "Not an expression extraction");
+  std::vector<RefactoringReplacement> Replacements;
+  const Expr *E = cast<Expr>(S);
+  QualType VarType = findExpressionLexicalType(FunctionLikeParentDecl, E,
+                                               E->getType(), PP, Context);
+  StringRef VarName = "extractedExpr";
+  std::unique_ptr<RefactoringResultAssociatedSymbol> CreatedSymbol =
+      llvm::make_unique<RefactoringResultAssociatedSymbol>(SymbolName(VarName));
+
+  SourceRange ExtractedTokenRange = CandidateExtractionInfo[0].Range;
+  SourceRange ExtractedCharRange = SourceRange(
+      ExtractedTokenRange.getBegin(),
+      getPreciseTokenLocEnd(ExtractedTokenRange.getEnd(),
+                            Context.getSourceManager(), Context.getLangOpts()));
+
+  // Create the variable that will hold the value of the duplicate expression.
+  std::string VariableDeclarationString;
+  llvm::raw_string_ostream OS(VariableDeclarationString);
+  VarType.print(OS, PP, /*PlaceHolder*/ VarName);
+  // FIXME: We should hook into the TypePrinter when moving over to llvm.org
+  // instead and get the offset from it.
+  unsigned NameOffset = StringRef(OS.str()).find(VarName);
+  OS << " = ";
+  OS << Lexer::getSourceText(CharSourceRange::getCharRange(ExtractedCharRange),
+                             Context.getSourceManager(), Context.getLangOpts());
+  OS << ";\n";
+
+  // Variable declaration.
+  SourceLocation InsertionLoc =
+      extract::locationForExtractedVariableDeclaration(
+          E, FunctionLikeParentDecl, Context.getSourceManager());
+  Replacements.push_back(RefactoringReplacement(
+      SourceRange(InsertionLoc, InsertionLoc), OS.str(), CreatedSymbol.get(),
+      RefactoringReplacement::AssociatedSymbolLocation(
+          llvm::makeArrayRef(NameOffset), /*IsDeclaration=*/true)));
+  // Replace the expression with the variable.
+  Replacements.push_back(
+      RefactoringReplacement(ExtractedCharRange, VarName, CreatedSymbol.get(),
+                             /*NameOffset=*/llvm::makeArrayRef(unsigned(0))));
+
+  RefactoringResult Result(std::move(Replacements));
+  Result.AssociatedSymbols.push_back(std::move(CreatedSymbol));
+  return std::move(Result);
+}
+
 llvm::Expected<RefactoringResult> ExtractOperation::perform(
     ASTContext &Context, const Preprocessor &ThePreprocessor,
     const RefactoringOptionSet &Options, unsigned SelectedCandidateIndex) {
@@ -1441,6 +1516,9 @@ llvm::Expected<RefactoringResult> ExtractOperation::perform(
   PP.SuppressStrongLifetime = true;
   PP.SuppressLifetimeQualifiers = true;
   PP.SuppressUnwrittenScope = true;
+
+  if (isExpressionExtraction())
+    return performExpressionExtraction(Context, PP);
 
   const Stmt *S =
       CandidateExtractionInfo[SelectedCandidateIndex].AnalyzedStatement
@@ -1573,7 +1651,7 @@ llvm::Expected<RefactoringResult> ExtractOperation::perform(
   }
   // Capture any fields if necessary.
   bool IsThisConstInCapturedFieldUses = true;
-  if (!IsMethodExtraction) {
+  if (!isMethodExtraction()) {
     for (const auto &I : Visitor.CapturedFields) {
       if (I.getSecond().isPassedByRefOrPtr() &&
           !I.getSecond().isRefOrPtrConst())
@@ -1592,7 +1670,7 @@ llvm::Expected<RefactoringResult> ExtractOperation::perform(
               return X.getName() < Y.getName();
             });
   // 'This'/'self' should be passed-in first.
-  if (!IsMethodExtraction && Visitor.CaptureThis) {
+  if (!isMethodExtraction() && Visitor.CaptureThis) {
     CapturedVariables.insert(
         CapturedVariables.begin(),
         CapturedVariable::getThis(
@@ -1612,7 +1690,7 @@ llvm::Expected<RefactoringResult> ExtractOperation::perform(
         PtrThisRewriter.TraverseStmt(const_cast<Stmt *>(S));
     } else
       PtrThisRewriter.TraverseStmt(const_cast<Stmt *>(S));
-  } else if (!IsMethodExtraction && Visitor.CaptureSelf &&
+  } else if (!isMethodExtraction() && Visitor.CaptureSelf &&
              EnclosingObjCMethod) {
     if (EnclosingObjCMethod->isInstanceMethod()) {
       // Instance methods rewrite 'self' into an 'object' parameter.
@@ -1638,7 +1716,7 @@ llvm::Expected<RefactoringResult> ExtractOperation::perform(
         SelfRewriter.TraverseStmt(const_cast<Stmt *>(S));
     }
   }
-  if (!IsMethodExtraction && Visitor.CaptureSuper && EnclosingObjCMethod) {
+  if (!isMethodExtraction() && Visitor.CaptureSuper && EnclosingObjCMethod) {
     if (EnclosingObjCMethod->isInstanceMethod())
       // Instance methods rewrite 'super' into an 'superObject' parameter.
       CapturedVariables.insert(Visitor.CaptureSelf
@@ -1701,7 +1779,8 @@ llvm::Expected<RefactoringResult> ExtractOperation::perform(
   StringRef ExtractedName = "extracted";
   llvm::SmallVector<StringRef, 4> ExtractedNamePieces;
   ExtractedNamePieces.push_back(ExtractedName);
-  if (IsMethodExtraction && EnclosingObjCMethod && !CapturedVariables.empty()) {
+  if (isMethodExtraction() && EnclosingObjCMethod &&
+      !CapturedVariables.empty()) {
     for (const auto &Var : llvm::makeArrayRef(CapturedVariables).drop_front())
       ExtractedNamePieces.push_back(Var.getName());
   }
@@ -1710,7 +1789,7 @@ llvm::Expected<RefactoringResult> ExtractOperation::perform(
           SymbolName(ExtractedNamePieces));
 
   SourceLocation FunctionExtractionLoc = computeFunctionExtractionLocation(
-      FunctionLikeParentDecl, IsMethodExtraction);
+      FunctionLikeParentDecl, isMethodExtraction());
   FunctionExtractionLoc =
       getLocationOfPrecedingComment(FunctionExtractionLoc, SM, LangOpts);
 
@@ -1719,7 +1798,7 @@ llvm::Expected<RefactoringResult> ExtractOperation::perform(
       [&](llvm::raw_string_ostream &OS,
           bool IsDefinition =
               true) -> RefactoringReplacement::AssociatedSymbolLocation {
-    if (IsMethodExtraction && EnclosingObjCMethod) {
+    if (isMethodExtraction() && EnclosingObjCMethod) {
       OS << (EnclosingObjCMethod->isClassMethod() ? '+' : '-') << " (";
       ReturnType.print(OS, PP);
       OS << ')';
@@ -1742,7 +1821,7 @@ llvm::Expected<RefactoringResult> ExtractOperation::perform(
           NameOffsets, /*IsDeclaration=*/true);
     }
     auto *FD = dyn_cast<FunctionDecl>(FunctionLikeParentDecl);
-    if (IsMethodExtraction && IsDefinition &&
+    if (isMethodExtraction() && IsDefinition &&
         !FD->getDescribedFunctionTemplate()) {
       // Print the class template parameter lists for an out-of-line method.
       for (unsigned I = 0,
@@ -1752,13 +1831,13 @@ llvm::Expected<RefactoringResult> ExtractOperation::perform(
         OS << "\n";
       }
     }
-    if (IsMethodExtraction && isEnclosingMethodStatic(FunctionLikeParentDecl))
+    if (isMethodExtraction() && isEnclosingMethodStatic(FunctionLikeParentDecl))
       OS << "static ";
-    else if (!IsMethodExtraction)
+    else if (!isMethodExtraction())
       OS << (isInHeader(FunctionExtractionLoc, SM) ? "inline " : "static ");
     ReturnType.print(OS, PP);
     OS << ' ';
-    if (IsMethodExtraction && IsDefinition)
+    if (isMethodExtraction() && IsDefinition)
       printEnclosingMethodScope(FunctionLikeParentDecl, OS, PP);
     unsigned NameOffset = OS.str().size();
     OS << ExtractedName << '(';
@@ -1770,14 +1849,14 @@ llvm::Expected<RefactoringResult> ExtractOperation::perform(
       Var.ParameterType.print(OS, PP, /*PlaceHolder=*/Var.getName());
     }
     OS << ')';
-    if (IsMethodExtraction && isEnclosingMethodConst(FunctionLikeParentDecl))
+    if (isMethodExtraction() && isEnclosingMethodConst(FunctionLikeParentDecl))
       OS << " const";
     return RefactoringReplacement::AssociatedSymbolLocation(
         NameOffset, /*IsDeclaration=*/true);
     ;
   };
 
-  if (IsMethodExtraction &&
+  if (isMethodExtraction() &&
       isEnclosingMethodOutOfLine(FunctionLikeParentDecl)) {
     // The location of the declaration should be either before the original
     // declararation, or, if this method has not declaration, somewhere
@@ -1786,7 +1865,7 @@ llvm::Expected<RefactoringResult> ExtractOperation::perform(
     SourceLocation DeclarationLoc;
     if (FunctionLikeParentDecl->getCanonicalDecl() != FunctionLikeParentDecl) {
       DeclarationLoc = computeFunctionExtractionLocation(
-          FunctionLikeParentDecl->getCanonicalDecl(), IsMethodExtraction);
+          FunctionLikeParentDecl->getCanonicalDecl(), isMethodExtraction());
       Placement = MethodDeclarationPlacement::Before;
     } else {
       auto LocAndPlacement =
@@ -1856,7 +1935,7 @@ llvm::Expected<RefactoringResult> ExtractOperation::perform(
   }
   InsertedOS << CandidateExtractionInfo[SelectedCandidateIndex].PreInsertedText;
   llvm::SmallVector<unsigned, 4> NameOffsets;
-  if (IsMethodExtraction && EnclosingObjCMethod) {
+  if (isMethodExtraction() && EnclosingObjCMethod) {
     InsertedOS << "[self ";
     NameOffsets.push_back(InsertedOS.str().size());
     InsertedOS << ExtractedName;

--- a/lib/Tooling/Refactor/ExtractRepeatedExpressionIntoVariable.cpp
+++ b/lib/Tooling/Refactor/ExtractRepeatedExpressionIntoVariable.cpp
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "ExtractionUtils.h"
 #include "RefactoringOperations.h"
 #include "SourceLocationUtilities.h"
 #include "clang/AST/AST.h"
@@ -322,22 +323,10 @@ public:
 } // end anonymous namespace
 
 static StringRef nameForExtractedVariable(const Expr *E) {
-  if (const auto *Call = dyn_cast<CallExpr>(E)) {
-    if (const auto *Fn = Call->getDirectCallee())
-      return Fn->getName();
-  } else if (const auto *Msg = dyn_cast<ObjCMessageExpr>(E)) {
-    if (const auto *M = Msg->getMethodDecl()) {
-      if (M->getSelector().isUnarySelector())
-        return M->getSelector().getNameForSlot(0);
-    }
-  } else if (const auto *PRE = dyn_cast<ObjCPropertyRefExpr>(E)) {
-    if (PRE->isImplicitProperty()) {
-      if (const auto *M = PRE->getImplicitPropertyGetter())
-        return M->getSelector().getNameForSlot(0);
-    } else if (const auto *Prop = PRE->getExplicitProperty())
-      return Prop->getName();
-  }
-  return "duplicate";
+  auto SuggestedName = extract::nameForExtractedVariable(E);
+  if (!SuggestedName)
+    return "duplicate";
+  return *SuggestedName;
 }
 
 llvm::Expected<RefactoringResult>

--- a/lib/Tooling/Refactor/ExtractRepeatedExpressionIntoVariable.cpp
+++ b/lib/Tooling/Refactor/ExtractRepeatedExpressionIntoVariable.cpp
@@ -19,7 +19,6 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/RecursiveASTVisitor.h"
-#include "llvm/Support/SaveAndRestore.h"
 
 using namespace clang;
 using namespace clang::tooling;
@@ -234,94 +233,6 @@ clang::tooling::initiateExtractRepeatedExpressionIntoVariableOperation(
   return Result;
 }
 
-namespace {
-
-/// Checks if a set of expressions is directly contained in some AST region.
-class StmtReachabilityChecker
-    : public RecursiveASTVisitor<StmtReachabilityChecker> {
-  const llvm::SmallPtrSetImpl<const Stmt *> &Expressions;
-  unsigned Count = 0;
-
-  StmtReachabilityChecker(
-      const llvm::SmallPtrSetImpl<const Stmt *> &Expressions)
-      : Expressions(Expressions) {}
-
-  bool areAllExpressionsReached() const { return Count == Expressions.size(); }
-
-public:
-  bool VisitStmt(const Stmt *S) {
-    if (Expressions.count(S)) {
-      ++Count;
-      if (areAllExpressionsReached())
-        return false;
-    }
-    return true;
-  }
-
-  static bool areAllExpressionsReachableFrom(
-      CompoundStmt *S, const llvm::SmallPtrSetImpl<const Stmt *> &Expressions) {
-    StmtReachabilityChecker Checker(Expressions);
-    Checker.TraverseStmt(S);
-    return Checker.areAllExpressionsReached();
-  }
-};
-
-/// Figures out where the extracted variable should go.
-class ExtractedVariableInsertionLocFinder
-    : public RecursiveASTVisitor<ExtractedVariableInsertionLocFinder> {
-  llvm::SmallPtrSet<const Stmt *, 4> Expressions;
-  llvm::SmallVector<std::pair<CompoundStmt *, const Stmt *>, 4>
-      InsertionCandidateStack;
-  bool IsPrevCompoundStmt = false;
-
-public:
-  SourceLocation Loc;
-
-  /// Initializes the insertion location finder using the set of duplicate
-  /// \p Expressions from one function.
-  ExtractedVariableInsertionLocFinder(ArrayRef<const Expr *> Expressions) {
-    for (const Expr *E : Expressions)
-      this->Expressions.insert(E);
-  }
-
-  bool TraverseStmt(Stmt *S) {
-    if (!S)
-      return RecursiveASTVisitor::TraverseStmt(S);
-    if (IsPrevCompoundStmt && !InsertionCandidateStack.empty())
-      InsertionCandidateStack.back().second = S;
-    llvm::SaveAndRestore<bool> IsPrevCompoundStmtTracker(IsPrevCompoundStmt,
-                                                         false);
-    if (auto *CS = dyn_cast<CompoundStmt>(S)) {
-      IsPrevCompoundStmt = true;
-      InsertionCandidateStack.emplace_back(CS, nullptr);
-      return RecursiveASTVisitor::TraverseStmt(S);
-    }
-    return RecursiveASTVisitor::TraverseStmt(S);
-  }
-
-  bool VisitStmt(const Stmt *S) {
-    if (Expressions.count(S)) {
-      // The insertion location should be in the first compound statement that
-      // includes all of the expressions as descendants as we want the new
-      // variable to be visible to all uses.
-      for (auto I = InsertionCandidateStack.rbegin(),
-                E = InsertionCandidateStack.rend();
-           I != E; ++I) {
-        if (StmtReachabilityChecker::areAllExpressionsReachableFrom(
-                I->first, Expressions) &&
-            I->second) {
-          Loc = I->second->getLocStart();
-          break;
-        }
-      }
-      return false;
-    }
-    return true;
-  }
-};
-
-} // end anonymous namespace
-
 static StringRef nameForExtractedVariable(const Expr *E) {
   auto SuggestedName = extract::nameForExtractedVariable(E);
   if (!SuggestedName)
@@ -336,9 +247,10 @@ ExtractRepeatedExpressionIntoVariableOperation::perform(
   std::vector<RefactoringReplacement> Replacements;
 
   const SourceManager &SM = Context.getSourceManager();
-  ExtractedVariableInsertionLocFinder LocFinder(DuplicateExpressions);
-  LocFinder.TraverseDecl(const_cast<Decl *>(ParentDecl));
-  if (LocFinder.Loc.isInvalid())
+  SourceLocation InsertionLoc =
+      extract::locationForExtractedVariableDeclaration(DuplicateExpressions,
+                                                       ParentDecl, SM);
+  if (InsertionLoc.isInvalid())
     return llvm::make_error<RefactoringOperationError>(
         "no appropriate insertion location found");
 
@@ -356,9 +268,6 @@ ExtractRepeatedExpressionIntoVariableOperation::perform(
   OS << " = ";
   E->printPretty(OS, /*Helper=*/nullptr, Context.getPrintingPolicy());
   OS << ";\n";
-  SourceLocation InsertionLoc = LocFinder.Loc;
-  if (InsertionLoc.isMacroID())
-    InsertionLoc = SM.getExpansionLoc(InsertionLoc);
   Replacements.emplace_back(SourceRange(InsertionLoc, InsertionLoc), OS.str());
 
   // Replace the duplicates with a reference to the variable.

--- a/lib/Tooling/Refactor/ExtractionUtils.cpp
+++ b/lib/Tooling/Refactor/ExtractionUtils.cpp
@@ -95,7 +95,9 @@ public:
     if (auto *CS = dyn_cast<CompoundStmt>(S)) {
       IsPrevCompoundStmt = true;
       InsertionCandidateStack.emplace_back(CS, nullptr);
-      return RecursiveASTVisitor::TraverseStmt(S);
+      RecursiveASTVisitor::TraverseStmt(S);
+      InsertionCandidateStack.pop_back();
+      return true;
     }
     return RecursiveASTVisitor::TraverseStmt(S);
   }

--- a/lib/Tooling/Refactor/ExtractionUtils.cpp
+++ b/lib/Tooling/Refactor/ExtractionUtils.cpp
@@ -10,6 +10,9 @@
 #include "ExtractionUtils.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprObjC.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/Support/SaveAndRestore.h"
 
 using namespace clang;
 
@@ -30,4 +33,103 @@ Optional<StringRef> tooling::extract::nameForExtractedVariable(const Expr *E) {
       return Prop->getName();
   }
   return None;
+}
+
+namespace {
+
+/// Checks if a set of expressions is directly contained in some AST region.
+class StmtReachabilityChecker
+    : public RecursiveASTVisitor<StmtReachabilityChecker> {
+  const llvm::SmallPtrSetImpl<const Stmt *> &Expressions;
+  unsigned Count = 0;
+
+  StmtReachabilityChecker(
+      const llvm::SmallPtrSetImpl<const Stmt *> &Expressions)
+      : Expressions(Expressions) {}
+
+  bool areAllExpressionsReached() const { return Count == Expressions.size(); }
+
+public:
+  bool VisitStmt(const Stmt *S) {
+    if (Expressions.count(S)) {
+      ++Count;
+      if (areAllExpressionsReached())
+        return false;
+    }
+    return true;
+  }
+
+  static bool areAllExpressionsReachableFrom(
+      CompoundStmt *S, const llvm::SmallPtrSetImpl<const Stmt *> &Expressions) {
+    StmtReachabilityChecker Checker(Expressions);
+    Checker.TraverseStmt(S);
+    return Checker.areAllExpressionsReached();
+  }
+};
+
+/// Figures out where the extracted variable should go.
+class ExtractedVariableInsertionLocFinder
+    : public RecursiveASTVisitor<ExtractedVariableInsertionLocFinder> {
+  llvm::SmallPtrSet<const Stmt *, 4> Expressions;
+  llvm::SmallVector<std::pair<CompoundStmt *, const Stmt *>, 4>
+      InsertionCandidateStack;
+  bool IsPrevCompoundStmt = false;
+
+public:
+  SourceLocation Loc;
+
+  /// Initializes the insertion location finder using the set of duplicate
+  /// \p Expressions from one function.
+  ExtractedVariableInsertionLocFinder(ArrayRef<const Expr *> Expressions) {
+    for (const Expr *E : Expressions)
+      this->Expressions.insert(E);
+  }
+
+  bool TraverseStmt(Stmt *S) {
+    if (!S)
+      return RecursiveASTVisitor::TraverseStmt(S);
+    if (IsPrevCompoundStmt && !InsertionCandidateStack.empty())
+      InsertionCandidateStack.back().second = S;
+    llvm::SaveAndRestore<bool> IsPrevCompoundStmtTracker(IsPrevCompoundStmt,
+                                                         false);
+    if (auto *CS = dyn_cast<CompoundStmt>(S)) {
+      IsPrevCompoundStmt = true;
+      InsertionCandidateStack.emplace_back(CS, nullptr);
+      return RecursiveASTVisitor::TraverseStmt(S);
+    }
+    return RecursiveASTVisitor::TraverseStmt(S);
+  }
+
+  bool VisitStmt(const Stmt *S) {
+    if (Expressions.count(S)) {
+      // The insertion location should be in the first compound statement that
+      // includes all of the expressions as descendants as we want the new
+      // variable to be visible to all uses.
+      for (auto I = InsertionCandidateStack.rbegin(),
+                E = InsertionCandidateStack.rend();
+           I != E; ++I) {
+        if (StmtReachabilityChecker::areAllExpressionsReachableFrom(
+                I->first, Expressions) &&
+            I->second) {
+          Loc = I->second->getLocStart();
+          break;
+        }
+      }
+      return false;
+    }
+    return true;
+  }
+};
+
+} // end anonymous namespace
+
+SourceLocation tooling::extract::locationForExtractedVariableDeclaration(
+    ArrayRef<const Expr *> Expressions, const Decl *ParentDecl,
+    const SourceManager &SM) {
+  ExtractedVariableInsertionLocFinder LocFinder(Expressions);
+  LocFinder.TraverseDecl(const_cast<Decl *>(ParentDecl));
+  SourceLocation Result = LocFinder.Loc;
+  if (Result.isValid() && Result.isMacroID())
+    return SM.getExpansionLoc(Result);
+  return Result;
 }

--- a/lib/Tooling/Refactor/ExtractionUtils.cpp
+++ b/lib/Tooling/Refactor/ExtractionUtils.cpp
@@ -1,0 +1,33 @@
+//===--- ExtractionUtils.cpp - Extraction helper functions ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "ExtractionUtils.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/ExprObjC.h"
+
+using namespace clang;
+
+Optional<StringRef> tooling::extract::nameForExtractedVariable(const Expr *E) {
+  if (const auto *Call = dyn_cast<CallExpr>(E)) {
+    if (const auto *Fn = Call->getDirectCallee())
+      return Fn->getName();
+  } else if (const auto *Msg = dyn_cast<ObjCMessageExpr>(E)) {
+    if (const auto *M = Msg->getMethodDecl()) {
+      if (M->getSelector().isUnarySelector())
+        return M->getSelector().getNameForSlot(0);
+    }
+  } else if (const auto *PRE = dyn_cast<ObjCPropertyRefExpr>(E)) {
+    if (PRE->isImplicitProperty()) {
+      if (const auto *M = PRE->getImplicitPropertyGetter())
+        return M->getSelector().getNameForSlot(0);
+    } else if (const auto *Prop = PRE->getExplicitProperty())
+      return Prop->getName();
+  }
+  return None;
+}

--- a/lib/Tooling/Refactor/ExtractionUtils.h
+++ b/lib/Tooling/Refactor/ExtractionUtils.h
@@ -16,6 +16,8 @@
 namespace clang {
 
 class Expr;
+class Decl;
+class SourceManager;
 
 namespace tooling {
 namespace extract {
@@ -23,6 +25,13 @@ namespace extract {
 /// Returns a good name for an extracted variable based on the declaration
 /// that's used in the given expression \p E.
 Optional<StringRef> nameForExtractedVariable(const Expr *E);
+
+/// Returns an appropriate location for a variable declaration that will be
+/// visible to all the given expressions.
+SourceLocation
+locationForExtractedVariableDeclaration(ArrayRef<const Expr *> Expressions,
+                                        const Decl *ParentDecl,
+                                        const SourceManager &SM);
 
 } // end namespace extract
 } // end namespace tooling

--- a/lib/Tooling/Refactor/ExtractionUtils.h
+++ b/lib/Tooling/Refactor/ExtractionUtils.h
@@ -1,0 +1,31 @@
+//===--- ExtractionUtils.h - Extraction helper functions ------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LIB_TOOLING_REFACTOR_EXTRACTION_UTILS_H
+#define LLVM_CLANG_LIB_TOOLING_REFACTOR_EXTRACTION_UTILS_H
+
+#include "clang/AST/Type.h"
+#include "clang/Basic/LLVM.h"
+
+namespace clang {
+
+class Expr;
+
+namespace tooling {
+namespace extract {
+
+/// Returns a good name for an extracted variable based on the declaration
+/// that's used in the given expression \p E.
+Optional<StringRef> nameForExtractedVariable(const Expr *E);
+
+} // end namespace extract
+} // end namespace tooling
+} // end namespace clang
+
+#endif // LLVM_CLANG_LIB_TOOLING_REFACTOR_EXTRACTION_UTILS_H

--- a/lib/Tooling/Refactor/StmtUtils.h
+++ b/lib/Tooling/Refactor/StmtUtils.h
@@ -27,6 +27,11 @@ SourceLocation getLexicalEndLocForDecl(const Decl *D, const SourceManager &SM,
 /// statement.
 bool isSemicolonRequiredAfter(const Stmt *S);
 
+/// Returns true if the given statement \p S is an actual expression in the
+/// source. Assignment expressions are considered to be statements unless they
+/// are a part of an expression.
+bool isLexicalExpression(const Stmt *S, const Stmt *Parent);
+
 } // end namespace tooling
 } // end namespace clang
 

--- a/test/Refactor/Extract/extract-expression-into-var.cpp
+++ b/test/Refactor/Extract/extract-expression-into-var.cpp
@@ -1,0 +1,39 @@
+int call(int x);
+
+void extractExpressionIntoVar(int x, int y, int z) {
+  {
+    // expr1-begin: +1:13
+    int p = x + y - z;   // CHECK: "int extractedExpr = x + y;\n" [[@LINE]]:5 -> [[@LINE]]:5 [Symbol extracted-decl 0 1:5 -> 1:18]
+    // expr1-end: -1:19  // CHECK: "extractedExpr" [[@LINE-1]]:13 -> [[@LINE-1]]:18 [Symbol extracted-decl-ref 0 1:1 -> 1:14]
+    // expr2-begin: +1:6 // CHECK: "std::function<void (int)> extractedExpr = [&](int x) {\n       p = x;\n    };\n" [[@LINE+1]]:5 -> [[@LINE+1]]:5 [Symbol extracted-decl 0 1:27 -> 1:40]
+    ([&](int x) {
+       p = x;
+    })(0);
+    // expr2-end: -1:6   // CHECK: "extractedExpr" [[@LINE-3]]:6 -> [[@LINE-1]]:6
+  }
+  #define MACROARG(x) (x)
+  // expr3-begin: +1:20
+  int p = MACROARG(y + z) - x; // CHECK: "int extractedExpr = y + z;\n" [[@LINE]]:3 -> [[@LINE]]:3
+  // expr3-end: -1:25   // CHECK: "extractedExpr" [[@LINE-1]]:20 -> [[@LINE-1]]:25
+  #define MACROSTMT(x, y) int var = (x) + (y);
+  // expr4-begin: +1:16
+  MACROSTMT(0, call(p * z))   // CHECK: "int extractedExpr = call(p * z);\n" [[@LINE]]:3 -> [[@LINE]]:3
+  // expr4-end: -1:27   // CHECK: "extractedExpr" [[@LINE-1]]:16 -> [[@LINE-1]]:27
+}
+
+// RUN: clang-refactor-test perform -action extract-expression -selected=expr1 -selected=expr2 -selected=expr3 -selected=expr4 -emit-associated %s -std=c++11 | FileCheck %s
+
+// RUN: clang-refactor-test list-actions -at=%s:6:13 -selected=%s:6:13-6:18 %s -std=c++11 | FileCheck --check-prefix=CHECK-ACTION %s
+// CHECK-ACTION: Extract Expression
+
+void dontExtractStatement(int x, int y) {
+  // stmt1-begin: +1:3
+  x = y;
+  // stmt1-end: -1:8
+  // stmt2-begin: +1:3
+  return;
+  // stmt2-end: +0:1
+}
+
+// RUN: not clang-refactor-test perform -action extract-expression -selected=stmt1 -selected=stmt2 %s -std=c++11 2>&1 | FileCheck --check-prefix=CHECK-FAIL %s
+// CHECK-FAIL: Failed to initiate the refactoring action!

--- a/test/Refactor/Extract/extract-expression-into-var.m
+++ b/test/Refactor/Extract/extract-expression-into-var.m
@@ -1,0 +1,12 @@
+// RUN: clang-refactor-test perform -action extract-expression -selected=expr1 -selected=expr2 %s | FileCheck %s
+
+void extractExpressionIntoVar(int x, int y, int z) {
+  // expr1-begin: +1:9
+  (void)@selector(foo:bar:); // CHECK: "SEL extractedExpr = @selector(foo:bar:);\n" [[@LINE]]:3 -> [[@LINE]]:3
+  // expr1-end: -1:28        // CHECK: "extractedExpr" [[@LINE-1]]:9 -> [[@LINE-1]]:28
+  // expr2-begin: +1:4       // CHECK: "void (^extractedExpr)(void) = ^ {\n    // do nothing\n  };\n" [[@LINE+1]]:3 -> [[@LINE+1]]:3
+  (^ {
+    // do nothing
+  })();
+  // expr2-end: -1:4         // CHECK: "extractedExpr" [[@LINE-3]]:4 -> [[@LINE-1]]:4
+}


### PR DESCRIPTION
"Extract Expression" is a sub-action of extract.

Note: I thought I will use the new function from first NFC commit, which moves `nameForExtractedVariable` into a separate file, but decided against it.