### PR TITLE
[Lex] Expose a ModuleMacro's IdentifierInfo.

### DIFF
--- a/include/clang/Lex/MacroInfo.h
+++ b/include/clang/Lex/MacroInfo.h
@@ -510,6 +510,9 @@ public:
     ID.AddPointer(II);
   }
 
+  /// Get the name of the macro.
+  IdentifierInfo *getName() const { return II; }
+
   /// Get the ID of the module that exports this macro.
   Module *getOwningModule() const { return OwningModule; }
 

--- a/include/clang/Lex/MacroInfo.h
+++ b/include/clang/Lex/MacroInfo.h
@@ -266,11 +266,6 @@ public:
 
   void setUsedForHeaderGuard(bool Val) { UsedForHeaderGuard = Val; }
 
-  // FIXME: hack to get past build failures
-  unsigned getOwningModuleID() const {
-    return 0;
-  }
-
   void dump() const;
 
 private:


### PR DESCRIPTION
Support for apple/swift#10519.