### PR TITLE
Rdar 30851899 bridging pch mergemodule mismatch swift 4.0 branch

### DIFF
--- a/lib/Serialization/ASTReaderDecl.cpp
+++ b/lib/Serialization/ASTReaderDecl.cpp
@@ -125,6 +125,9 @@ namespace clang {
     void ReadObjCDefinitionData(struct ObjCInterfaceDecl::DefinitionData &Data);
     void MergeDefinitionData(ObjCInterfaceDecl *D,
                              struct ObjCInterfaceDecl::DefinitionData &&NewDD);
+    void ReadObjCDefinitionData(struct ObjCProtocolDecl::DefinitionData &Data);
+    void MergeDefinitionData(ObjCProtocolDecl *D,
+                             struct ObjCProtocolDecl::DefinitionData &&NewDD);
 
     static NamedDecl *getAnonymousDeclForMerging(ASTReader &Reader,
                                                  DeclContext *DC,
@@ -1032,18 +1035,8 @@ void ASTDeclReader::VisitObjCIvarDecl(ObjCIvarDecl *IVD) {
   IVD->setSynthesize(synth);
 }
 
-void ASTDeclReader::VisitObjCProtocolDecl(ObjCProtocolDecl *PD) {
-  RedeclarableResult Redecl = VisitRedeclarable(PD);
-  VisitObjCContainerDecl(PD);
-  mergeRedeclarable(PD, Redecl);
-
-  if (Record.readInt()) {
-    // Read the definition.
-    PD->allocateDefinitionData();
-
-    // Set the definition data of the canonical declaration, so other
-    // redeclarations will see it.
-    PD->getCanonicalDecl()->Data = PD->Data;
+void ASTDeclReader::ReadObjCDefinitionData(
+         struct ObjCProtocolDecl::DefinitionData &Data) {
 
     unsigned NumProtoRefs = Record.readInt();
     SmallVector<ObjCProtocolDecl *, 16> ProtoRefs;
@@ -1054,9 +1047,37 @@ void ASTDeclReader::VisitObjCProtocolDecl(ObjCProtocolDecl *PD) {
     ProtoLocs.reserve(NumProtoRefs);
     for (unsigned I = 0; I != NumProtoRefs; ++I)
       ProtoLocs.push_back(ReadSourceLocation());
-    PD->setProtocolList(ProtoRefs.data(), NumProtoRefs, ProtoLocs.data(),
-                        Reader.getContext());
+    Data.ReferencedProtocols.set(ProtoRefs.data(), NumProtoRefs,
+                                 ProtoLocs.data(), Reader.getContext());
+}
 
+void ASTDeclReader::MergeDefinitionData(ObjCProtocolDecl *D,
+         struct ObjCProtocolDecl::DefinitionData &&NewDD) {
+  // FIXME: odr checking?
+}
+
+void ASTDeclReader::VisitObjCProtocolDecl(ObjCProtocolDecl *PD) {
+  RedeclarableResult Redecl = VisitRedeclarable(PD);
+  VisitObjCContainerDecl(PD);
+  mergeRedeclarable(PD, Redecl);
+
+  if (Record.readInt()) {
+    // Read the definition.
+    PD->allocateDefinitionData();
+
+    ReadObjCDefinitionData(PD->data());
+
+    ObjCProtocolDecl *Canon = PD->getCanonicalDecl();
+    if (Canon->Data.getPointer()) {
+      // If we already have a definition, keep the definition invariant and
+      // merge the data.
+      MergeDefinitionData(Canon, std::move(PD->data()));
+      PD->Data = Canon->Data;
+    } else {
+      // Set the definition data of the canonical declaration, so other
+      // redeclarations will see it.
+      PD->getCanonicalDecl()->Data = PD->Data;
+    }
     // Note that we have deserialized a definition.
     Reader.PendingDefinitions.insert(PD);
   } else {

--- a/test/Modules/Inputs/lookup-assert-protocol/Base.h
+++ b/test/Modules/Inputs/lookup-assert-protocol/Base.h
@@ -1,0 +1,3 @@
+@protocol BaseProtocol
+- (void) test;
+@end

--- a/test/Modules/Inputs/lookup-assert-protocol/Derive.h
+++ b/test/Modules/Inputs/lookup-assert-protocol/Derive.h
@@ -1,0 +1,4 @@
+#include "Base.h"
+@protocol DerivedProtocol<BaseProtocol>
+- (void) test2;
+@end

--- a/test/Modules/Inputs/lookup-assert-protocol/H3.h
+++ b/test/Modules/Inputs/lookup-assert-protocol/H3.h
@@ -1,0 +1,1 @@
+#include "Base.h"

--- a/test/Modules/Inputs/lookup-assert-protocol/module.map
+++ b/test/Modules/Inputs/lookup-assert-protocol/module.map
@@ -1,0 +1,4 @@
+module X {
+  header "H3.h"
+  export *
+}

--- a/test/Modules/lookup-assert-protocol.m
+++ b/test/Modules/lookup-assert-protocol.m
@@ -1,0 +1,17 @@
+// RUN: rm -rf %t
+// RUN: %clang_cc1 -fmodules-cache-path=%t -fmodules -fimplicit-module-maps -I %S/Inputs/lookup-assert-protocol %s -verify
+// expected-no-diagnostics
+
+#include "Derive.h"
+#import <H3.h>
+
+__attribute__((objc_root_class))
+@interface Thing<DerivedProtocol>
+@end
+
+@implementation Thing
+- (void)test {
+}
+- (void)test2 {
+}
+@end


### PR DESCRIPTION
**Explanation**: Fix a bridging PCH crash caused by a clang bug

**Scope**: Causes failure-to-compile (appears as a deserialization error) unless user disables bridging PCH. Triggered by legal-but-clumsy misconfiguration in workspace, seemingly as-performed by cocoapods in unknown number of cases. Might be quite widespread.

**Radar**: 30851899

**Risk**: relatively low, it's not even clear to me that a user can detect it in C/ObjC, and it only makes an under-defined corner case of the module system a bit more-deterministic; it's just a corner-case that swift happens to hit when importing definitions from a nest of header symlinks, as produced by cocoapods.

**Testing**: Swift has a pending test for it https://github.com/apple/swift/pull/10658 ; at the clang level, it can't easily be checked in ObjC, but the misbehaviour can trigget an assertion in clang, which there's an accompanying test for here.