### PR TITLE
[swift-4.0-branch] [objc] Don't emit memset when result is ignored for struct-returning method calls

### DIFF
--- a/test/CodeGenObjC/stret-1.m
+++ b/test/CodeGenObjC/stret-1.m
@@ -14,8 +14,7 @@ int main(int argc, const char **argv)
 {
     [(id)(argc&~255) method];
     // CHECK: call void bitcast (i8* (i8*, i8*, ...)* @objc_msgSend to void (%struct.stret*, i8*, i8*)*)(%struct.stret* sret [[T0:%[^,]+]]
-    // CHECK: [[T0P:%.*]] = bitcast %struct.stret* [[T0]] to i8*
-    // CHECK: call void @llvm.memset.p0i8.i64(i8* [[T0P]], i8 0, i64 400, i32 4, i1 false)
+    // CHECK-NOT: call void @llvm.memset.p0i8.i64(
 
     [Test method];
     // CHECK: call void bitcast (i8* (i8*, i8*, ...)* @objc_msgSend to void (%struct.stret*, i8*, i8*)*)(%struct.stret* sret [[T1:%[^,]+]]


### PR DESCRIPTION
This is a cherry-pick/back-port of a part of r306838, "[objc] Don't require null-check and don't emit memset when result is ignored for struct-returning method calls". Fixes an issue with the emission of lifetime markers for struct-returning Obj-C msgSend calls.