### PR TITLE
[refactor][index] Handle ObjC method names with empty selector pieces

### DIFF
--- a/include/clang/Tooling/Refactor/SymbolName.h
+++ b/include/clang/Tooling/Refactor/SymbolName.h
@@ -52,6 +52,14 @@ public:
 
   ArrayRef<std::string> strings() const { return Strings; }
 
+  bool containsEmptyPiece() const {
+    for (const auto &String : Strings) {
+      if (String.empty())
+        return true;
+    }
+    return false;
+  }
+
   void print(raw_ostream &OS) const;
 
 private:

--- a/lib/Parse/ParseObjc.cpp
+++ b/lib/Parse/ParseObjc.cpp
@@ -1009,6 +1009,10 @@ IdentifierInfo *Parser::ParseObjCSelectorPiece(SourceLocation &SelectorLoc) {
   switch (Tok.getKind()) {
   default:
     return nullptr;
+  case tok::colon:
+    // Empty selector piece uses the location of the ':'.
+    SelectorLoc = Tok.getLocation();
+    return nullptr;
   case tok::ampamp:
   case tok::ampequal:
   case tok::amp:

--- a/lib/Tooling/Refactor/RenameIndexedFile.cpp
+++ b/lib/Tooling/Refactor/RenameIndexedFile.cpp
@@ -81,14 +81,6 @@ static MatchKind checkOccurrence(const IndexedOccurrence &Occurrence,
   if (BeginLoc.isInvalid())
     return MatchKind::None;
   StringRef SymbolNameStart = Symbol.Name[0];
-  SourceLocation EndLoc = BeginLoc.getLocWithOffset(std::max(
-      SymbolNameStart.size(),
-      size_t(1))); // Take empty Objective-C selector pieces into account.
-  if (!SM.isBeforeInTranslationUnit(BeginLoc, EndLoc)) {
-    // Ignore any invalid source ranges. This can occur if the indexed
-    // location is invalid.
-    return MatchKind::None;
-  }
   // Extract the token at the location.
   auto DecomposedLoc = SM.getDecomposedLoc(BeginLoc);
   const llvm::MemoryBuffer *File = SM.getBuffer(DecomposedLoc.first);

--- a/lib/Tooling/Refactor/USRFinder.cpp
+++ b/lib/Tooling/Refactor/USRFinder.cpp
@@ -127,8 +127,10 @@ public:
   bool VisitObjCMethodDecl(const ObjCMethodDecl *Decl) {
     // Check all of the selector source ranges.
     for (unsigned I = 0, E = Decl->getNumSelectorLocs(); I != E; ++I) {
-      if (!checkOccurrence(Decl, Decl->getSelectorLoc(I),
-                           Decl->getSelector().getNameForSlot(I).size()))
+      SourceLocation Loc = Decl->getSelectorLoc(I);
+      if (!checkOccurrence(Decl, Loc,
+                           Loc.getLocWithOffset(
+                               Decl->getSelector().getNameForSlot(I).size())))
         return false;
     }
     return true;
@@ -247,8 +249,10 @@ public:
 
     // Check all of the selector source ranges.
     for (unsigned I = 0, E = Expr->getNumSelectorLocs(); I != E; ++I) {
-      if (!checkOccurrence(Decl, Expr->getSelectorLoc(I),
-                           Decl->getSelector().getNameForSlot(I).size()))
+      SourceLocation Loc = Expr->getSelectorLoc(I);
+      if (!checkOccurrence(Decl, Loc,
+                           Loc.getLocWithOffset(
+                               Decl->getSelector().getNameForSlot(I).size())))
         return false;
     }
     return true;

--- a/test/Index/Core/index-source.m
+++ b/test/Index/Core/index-source.m
@@ -438,3 +438,28 @@ void testImplicitProperties(ImplicitProperties *c) {
 // CHECK: [[@LINE-1]]:22 | class-method/ObjC | classImplicit | c:objc(cs)ImplicitProperties(cm)classImplicit | +[ImplicitProperties classImplicit] | Ref,Call,RelCall,RelCont | rel: 1
 // CHECK-NEXT: RelCall,RelCont | testImplicitProperties | c:@F@testImplicitProperties
 }
+
+@interface EmptySelectors
+
+- (int):(int)_; // CHECK: [[@LINE]]:8 | instance-method/ObjC | : | c:objc(cs)EmptySelectors(im): | -[EmptySelectors :]
+- (void)test: (int)x :(int)y; // CHECK: [[@LINE]]:9 | instance-method/ObjC | test:: | c:objc(cs)EmptySelectors(im)test:: | -[EmptySelectors test::]
+- (void):(int)_ :(int)m:(int)z; // CHECK: [[@LINE]]:9 | instance-method/ObjC | ::: | c:objc(cs)EmptySelectors(im)::: | -[EmptySelectors :::]
+
+@end
+
+@implementation EmptySelectors
+
+- (int):(int)_ { // CHECK: [[@LINE]]:8 | instance-method/ObjC | : | c:objc(cs)EmptySelectors(im): | -[EmptySelectors :]
+  [self :2]; // CHECK: [[@LINE]]:9 | instance-method/ObjC | : | c:objc(cs)EmptySelectors(im): | -[EmptySelectors :]
+  return 0;
+}
+
+- (void)test: (int)x :(int)y { // CHECK: [[@LINE]]:9 | instance-method/ObjC | test:: | c:objc(cs)EmptySelectors(im)test:: | -[EmptySelectors test::]
+}
+
+- (void) :(int)_ :(int)m :(int)z { // CHECK: [[@LINE]]:10 | instance-method/ObjC | ::: | c:objc(cs)EmptySelectors(im)::: | -[EmptySelectors :::]
+  [self test:0:1]; // CHECK: [[@LINE]]:9 | instance-method/ObjC | test:: | c:objc(cs)EmptySelectors(im)test:: | -[EmptySelectors test::]
+  [self: 0: 1: 2]; // CHECK: [[@LINE]]:8 | instance-method/ObjC | ::: | c:objc(cs)EmptySelectors(im)::: | -[EmptySelectors :::]
+}
+
+@end

--- a/test/Refactor/Rename/IndexedObjCMethodEmptySelector.mm
+++ b/test/Refactor/Rename/IndexedObjCMethodEmptySelector.mm
@@ -1,0 +1,49 @@
+
+@interface EmptySelectorsRule_Psych
+
+- (int):(int)_; // CHECK1: rename [[@LINE]]:8 -> [[@LINE]]:8
+- (void)test: (int)x :(int)y; // CHECK2: rename [[@LINE]]:9 -> [[@LINE]]:13, [[@LINE]]:22 -> [[@LINE]]:22
+- (void):(int)_ :(int) m:(int)z; // CHECK3: rename [[@LINE]]:9 -> [[@LINE]]:9, [[@LINE]]:17 -> [[@LINE]]:17, [[@LINE]]:25 -> [[@LINE]]:25
+
+@end
+
+namespace g {
+    int x;
+}
+
+@implementation EmptySelectorsRule_Psych
+
+- (int):(int)_ { // CHECK1: rename [[@LINE]]:8 -> [[@LINE]]:8
+    [self :2];   // CHECK1: rename [[@LINE]]:11 -> [[@LINE]]:11
+    SEL s0 = @selector(:); // CHECK1: selector [[@LINE]]:24 -> [[@LINE]]:24
+    // CHECK1-NOT: comment
+    // CHECK1-NOT: rename
+    // CHECK1-NOT: selector
+// RUN: clang-refactor-test rename-indexed-file -name=: -new-name=foo -indexed-file=%s -indexed-symbol-kind=objc-im -indexed-at=4:8 -indexed-at=16:8 -indexed-at=objc-message:17:11 %s | FileCheck --check-prefix=CHECK1 %s
+    return 0;
+}
+- (void)test: (int)x :(int)y { } // CHECK2: rename [[@LINE]]:9 -> [[@LINE]]:13, [[@LINE]]:22 -> [[@LINE]]:22
+- (void) :(int)_ :(int)m :(int)z { // CHECK3: rename [[@LINE]]:10 -> [[@LINE]]:10, [[@LINE]]:18 -> [[@LINE]]:18, [[@LINE]]:26 -> [[@LINE]]:26
+    [self test:0:1]; // CHECK2: rename [[@LINE]]:11 -> [[@LINE]]:15, [[@LINE]]:17 -> [[@LINE]]:17
+    SEL s1 = @selector(test::); // CHECK2: selector [[@LINE]]:24 -> [[@LINE]]:28, [[@LINE]]:29 -> [[@LINE]]:29
+    @selector(test: :); // CHECK2: selector [[@LINE]]:15 -> [[@LINE]]:19, [[@LINE]]:21 -> [[@LINE]]:21
+    // CHECK2-NOT: comment
+    // CHECK2-NOT: rename
+    // CHECK2-NOT: selector
+// RUN: clang-refactor-test rename-indexed-file -name=test:: -new-name=foo:bar: -indexed-file=%s -indexed-symbol-kind=objc-im -indexed-at=5:9 -indexed-at=25:9 -indexed-at=objc-message:27:11 %s | FileCheck --check-prefix=CHECK2 %s
+
+    [self: ::g::x + ([self: 0]):~0 :3]; // CHECK3: rename [[@LINE]]:10 -> [[@LINE]]:10, [[@LINE]]:32 -> [[@LINE]]:32, [[@LINE]]:36 -> [[@LINE]]:36
+    SEL s2 = @selector(:::); // CHECK3: selector [[@LINE]]:24 -> [[@LINE]]:24, [[@LINE]]:25 -> [[@LINE]]:25, [[@LINE]]:26 -> [[@LINE]]:26
+    @selector(: ::); // CHECK3: selector [[@LINE]]:15 -> [[@LINE]]:15, [[@LINE]]:17 -> [[@LINE]]:17, [[@LINE]]:18 -> [[@LINE]]:18
+    @selector(::::); // not matching.
+    // CHECK3-NOT: comment
+    // CHECK3-NOT: rename
+    // CHECK3-NOT: selector
+// RUN: clang-refactor-test rename-indexed-file -name=::: -new-name=do:stuff:: -indexed-file=%s -indexed-symbol-kind=objc-im -indexed-at=6:9 -indexed-at=26:10 -indexed-at=objc-message:35:10 %s | FileCheck --check-prefix=CHECK3 %s
+
+    // NO Textual matches: text:
+    // :
+    // :::
+}
+
+@end

--- a/test/Refactor/Rename/ObjCMethod.m
+++ b/test/Refactor/Rename/ObjCMethod.m
@@ -133,3 +133,18 @@
 @end
 // RUN: not clang-refactor-test rename-initiate -at=%s:130:3 -new-name=foo %s -Wno-objc-root-class 2>&1 | FileCheck --check-prefix=CHECK-NORENAME %s
 // CHECK-NORENAME: could not rename symbol at the given location
+
+@interface EmptySelectorsRule_Psych
+
+- (void):(int)_ :(int) m:(int)z; // EMPTY-SELECTOR: rename [[@LINE]]:9 -> [[@LINE]]:9, [[@LINE]]:17 -> [[@LINE]]:17, [[@LINE]]:25 -> [[@LINE]]:25
+
+@end
+
+@implementation EmptySelectorsRule_Psych
+
+- (void) :(int)_ :(int)m :(int)z { // EMPTY-SELECTOR: rename [[@LINE]]:10 -> [[@LINE]]:10, [[@LINE]]:18 -> [[@LINE]]:18, [[@LINE]]:26 -> [[@LINE]]:26
+    [self: 15:0 :3]; // EMPTY-SELECTOR: rename [[@LINE]]:10 -> [[@LINE]]:10, [[@LINE]]:14 -> [[@LINE]]:14, [[@LINE]]:17 -> [[@LINE]]:17
+}
+// RUN: clang-refactor-test rename-initiate -at=%s:139:9 -new-name=test:a: %s -Wno-objc-root-class | FileCheck --check-prefix=EMPTY-SELECTOR %s
+
+@end


### PR DESCRIPTION
1st commit: will go to upstream.
The other two: on GitHub.com/apple/swift-clang.