### PR TITLE
[refactor] "Generate Missing Function Definitions" should insert

### DIFF
--- a/include/clang/Tooling/Refactor/IndexerQuery.h
+++ b/include/clang/Tooling/Refactor/IndexerQuery.h
@@ -181,6 +181,33 @@ public:
 
 } // end namespace detail
 
+enum class QueryBoolResult {
+  Unknown,
+  Yes,
+  No,
+};
+
+// FIXME: Either PersistentDeclRef or Decl *
+template <typename T> struct Indexed {
+  T Decl;
+  // FIXME: Generalize better in the new refactoring engine.
+  QueryBoolResult BoolResult = QueryBoolResult::Unknown;
+
+  Indexed(T Decl, QueryBoolResult BoolResult = QueryBoolResult::Unknown)
+      : Decl(Decl), BoolResult(BoolResult) {}
+
+  Indexed(Indexed<T> &&Other) = default;
+  Indexed &operator=(Indexed<T> &&Other) = default;
+  Indexed(const Indexed<T> &Other) = default;
+  Indexed &operator=(const Indexed<T> &Other) = default;
+
+  /// True iff the declaration is not defined in the entire project.
+  bool isNotDefined() const {
+    // FIXME: This is hack. Need a better system in the new engine.
+    return BoolResult == QueryBoolResult::Yes;
+  }
+};
+
 /// Transforms one set of declarations into another using some predicate.
 class DeclarationsQuery : public IndexerQuery {
   static const char *BaseUIDString;
@@ -189,7 +216,7 @@ class DeclarationsQuery : public IndexerQuery {
   std::unique_ptr<detail::DeclPredicateNode> Predicate;
 
 protected:
-  std::vector<PersistentDeclRef<Decl>> Output;
+  std::vector<Indexed<PersistentDeclRef<Decl>>> Output;
 
 public:
   DeclarationsQuery(std::vector<const Decl *> Input,
@@ -203,7 +230,7 @@ public:
 
   void invalidateTUSpecificState() override { Input.clear(); }
 
-  void setOutput(std::vector<PersistentDeclRef<Decl>> Output) {
+  void setOutput(std::vector<Indexed<PersistentDeclRef<Decl>>> Output) {
     this->Output = Output;
   }
 
@@ -238,10 +265,11 @@ public:
       : DeclarationsQuery(std::vector<const Decl *>(Input.begin(), Input.end()),
                           std::move(Predicate)) {}
 
-  std::vector<PersistentDeclRef<T>> getOutput() const {
-    std::vector<PersistentDeclRef<T>> Results;
+  std::vector<Indexed<PersistentDeclRef<T>>> getOutput() const {
+    std::vector<Indexed<PersistentDeclRef<T>>> Results;
     for (const auto &Ref : DeclarationsQuery::Output)
-      Results.push_back(PersistentDeclRef<T>(Ref.USR));
+      Results.push_back(Indexed<PersistentDeclRef<T>>(
+          PersistentDeclRef<T>(Ref.Decl.USR), Ref.BoolResult));
     return Results;
   }
 };

--- a/include/clang/Tooling/Refactor/IndexerQuery.h
+++ b/include/clang/Tooling/Refactor/IndexerQuery.h
@@ -187,14 +187,14 @@ enum class QueryBoolResult {
   No,
 };
 
-// FIXME: Either PersistentDeclRef or Decl *
+// FIXME: Check that 'T' is either a PersistentDeclRef<> or a Decl *.
 template <typename T> struct Indexed {
   T Decl;
   // FIXME: Generalize better in the new refactoring engine.
-  QueryBoolResult BoolResult = QueryBoolResult::Unknown;
+  QueryBoolResult IsNotDefined;
 
-  Indexed(T Decl, QueryBoolResult BoolResult = QueryBoolResult::Unknown)
-      : Decl(Decl), BoolResult(BoolResult) {}
+  Indexed(T Decl, QueryBoolResult IsNotDefined = QueryBoolResult::Unknown)
+      : Decl(Decl), IsNotDefined(IsNotDefined) {}
 
   Indexed(Indexed<T> &&Other) = default;
   Indexed &operator=(Indexed<T> &&Other) = default;
@@ -204,7 +204,7 @@ template <typename T> struct Indexed {
   /// True iff the declaration is not defined in the entire project.
   bool isNotDefined() const {
     // FIXME: This is hack. Need a better system in the new engine.
-    return BoolResult == QueryBoolResult::Yes;
+    return IsNotDefined == QueryBoolResult::Yes;
   }
 };
 
@@ -269,7 +269,7 @@ public:
     std::vector<Indexed<PersistentDeclRef<T>>> Results;
     for (const auto &Ref : DeclarationsQuery::Output)
       Results.push_back(Indexed<PersistentDeclRef<T>>(
-          PersistentDeclRef<T>(Ref.Decl.USR), Ref.BoolResult));
+          PersistentDeclRef<T>(Ref.Decl.USR), Ref.IsNotDefined));
     return Results;
   }
 };

--- a/lib/Tooling/Refactor/ImplementDeclaredMethods.cpp
+++ b/lib/Tooling/Refactor/ImplementDeclaredMethods.cpp
@@ -427,7 +427,7 @@ ImplementDeclaredObjCMethodsOperation::runInImplementationAST(
   llvm::raw_string_ostream OS(MethodString);
 
   assert(MethodDeclarations.size() >= SelectedMethods.size() &&
-         "less declarations than selected methods?");
+         "fewer declarations than selected methods?");
   for (const auto &I : llvm::enumerate(SelectedMethods)) {
     indexer::Indexed<const ObjCMethodDecl *> Decl = I.value();
     // Skip methods that are already defined.

--- a/lib/Tooling/Refactor/ImplementDeclaredMethods.cpp
+++ b/lib/Tooling/Refactor/ImplementDeclaredMethods.cpp
@@ -76,10 +76,9 @@ public:
   static void addInlineBody(const CXXMethodDecl *MD, const ASTContext &Context,
                             std::vector<RefactoringReplacement> &Replacements);
 
-  static llvm::Expected<RefactoringResult>
-  runInImplementationAST(ASTContext &Context, const FileID &File,
-                         const CXXRecordDecl *Class,
-                         ArrayRef<const CXXMethodDecl *> SelectedMethods);
+  static llvm::Expected<RefactoringResult> runInImplementationAST(
+      ASTContext &Context, const FileID &File, const CXXRecordDecl *Class,
+      ArrayRef<indexer::Indexed<const CXXMethodDecl *>> SelectedMethods);
 };
 
 class ImplementDeclaredObjCMethodsOperation
@@ -104,11 +103,11 @@ public:
           const RefactoringOptionSet &Options,
           unsigned SelectedCandidateIndex) override;
 
-  static llvm::Expected<RefactoringResult>
-  runInImplementationAST(ASTContext &Context, const FileID &File,
-                         const ObjCContainerDecl *Container,
-                         const ObjCInterfaceDecl *Interface,
-                         ArrayRef<const ObjCMethodDecl *> SelectedMethods);
+  static llvm::Expected<RefactoringResult> runInImplementationAST(
+      ASTContext &Context, const FileID &File,
+      const ObjCContainerDecl *Container, const ObjCInterfaceDecl *Interface,
+      ArrayRef<std::string> MethodDeclarations,
+      ArrayRef<indexer::Indexed<const ObjCMethodDecl *>> SelectedMethods);
 };
 
 /// Returns true if the given Objective-C method has an implementation.
@@ -224,7 +223,7 @@ static bool containsUsingOf(const NamespaceDecl *ND,
 llvm::Expected<RefactoringResult>
 ImplementDeclaredCXXMethodsOperation::runInImplementationAST(
     ASTContext &Context, const FileID &File, const CXXRecordDecl *Class,
-    ArrayRef<const CXXMethodDecl *> SelectedMethods) {
+    ArrayRef<indexer::Indexed<const CXXMethodDecl *>> SelectedMethods) {
   if (!Class)
     return llvm::make_error<RefactoringOperationError>(
         "the target class is not defined in the continuation AST unit");
@@ -316,7 +315,8 @@ ImplementDeclaredCXXMethodsOperation::runInImplementationAST(
   PP.SuppressLifetimeQualifiers = true;
   PP.SuppressUnwrittenScope = true;
   OS << "\n";
-  for (const CXXMethodDecl *MD : SelectedMethods) {
+  for (const auto &I : SelectedMethods) {
+    const CXXMethodDecl *MD = I.Decl;
     // Check if the method is already defined.
     if (!MD)
       continue;
@@ -369,24 +369,41 @@ ImplementDeclaredObjCMethodsOperation::perform(
     ASTContext &Context, const Preprocessor &ThePreprocessor,
     const RefactoringOptionSet &Options, unsigned SelectedCandidateIndex) {
   using namespace indexer;
+
+  // Print the methods before running the continuation because the continuation
+  // TU might not have these method declarations (e.g. category implemented in
+  // the class implementation).
+  PrintingPolicy PP = Context.getPrintingPolicy();
+  PP.PolishForDeclaration = true;
+  PP.SuppressStrongLifetime = true;
+  PP.SuppressLifetimeQualifiers = true;
+  PP.SuppressUnwrittenScope = true;
+  std::vector<std::string> MethodDeclarations;
+  for (const ObjCMethodDecl *MD : SelectedMethods) {
+    std::string MethodDeclStr;
+    llvm::raw_string_ostream MethodOS(MethodDeclStr);
+    MD->print(MethodOS, PP);
+    MethodDeclarations.push_back(std::move(MethodOS.str()));
+  }
+
   return continueInExternalASTUnit(
       fileThatShouldContainImplementationOf(Container), runInImplementationAST,
-      Container, Interface,
+      Container, Interface, MethodDeclarations,
       filter(llvm::makeArrayRef(SelectedMethods),
              [](const DeclEntity &D) { return !D.isDefined(); }));
 }
 
 static const ObjCImplDecl *
 getImplementationContainer(const ObjCContainerDecl *Container,
-                           const ObjCInterfaceDecl *Interface) {
+                           const ObjCInterfaceDecl *Interface = nullptr) {
   if (!Container)
-    return nullptr;
+    return Interface ? getImplementationContainer(Interface) : nullptr;
   if (const auto *ID = dyn_cast<ObjCInterfaceDecl>(Container))
     return ID->getImplementation();
   if (const auto *CD = dyn_cast<ObjCCategoryDecl>(Container)) {
     if (const auto *Impl = CD->getImplementation())
       return Impl;
-    return getImplementationContainer(Interface, /*Interface=*/nullptr);
+    return getImplementationContainer(Interface);
   }
   return nullptr;
 }
@@ -395,7 +412,8 @@ llvm::Expected<RefactoringResult>
 ImplementDeclaredObjCMethodsOperation::runInImplementationAST(
     ASTContext &Context, const FileID &File, const ObjCContainerDecl *Container,
     const ObjCInterfaceDecl *Interface,
-    ArrayRef<const ObjCMethodDecl *> SelectedMethods) {
+    ArrayRef<std::string> MethodDeclarations,
+    ArrayRef<indexer::Indexed<const ObjCMethodDecl *>> SelectedMethods) {
   const ObjCImplDecl *ImplementationContainer =
       getImplementationContainer(Container, Interface);
   if (!ImplementationContainer)
@@ -408,21 +426,15 @@ ImplementDeclaredObjCMethodsOperation::runInImplementationAST(
   std::string MethodString;
   llvm::raw_string_ostream OS(MethodString);
 
-  PrintingPolicy PP = Context.getPrintingPolicy();
-  PP.PolishForDeclaration = true;
-  PP.SuppressStrongLifetime = true;
-  PP.SuppressLifetimeQualifiers = true;
-  PP.SuppressUnwrittenScope = true;
-  for (const ObjCMethodDecl *MD : SelectedMethods) {
+  assert(MethodDeclarations.size() >= SelectedMethods.size() &&
+         "less declarations than selected methods?");
+  for (const auto &I : llvm::enumerate(SelectedMethods)) {
+    indexer::Indexed<const ObjCMethodDecl *> Decl = I.value();
     // Skip methods that are already defined.
-    if (!MD)
+    if (!Decl.isNotDefined())
       continue;
 
-    std::string MethodDeclStr;
-    llvm::raw_string_ostream MethodOS(MethodDeclStr);
-    MD->print(MethodOS, PP);
-
-    OS << StringRef(MethodOS.str()).drop_back(); // Drop the ';'
+    OS << StringRef(MethodDeclarations[I.index()]).drop_back(); // Drop the ';'
     OS << " { \n  <#code#>;\n}\n\n";
   }
   SourceLocation InsertionLoc = ImplementationContainer->getLocEnd();

--- a/lib/Tooling/Refactor/IndexerQueries.cpp
+++ b/lib/Tooling/Refactor/IndexerQueries.cpp
@@ -116,13 +116,15 @@ IndexerQuery::loadResultsFromYAML(StringRef Source,
       for (const auto &PredicateResult : Result.PredicateResults) {
         if (PredicateResult.Name != ActualPredicate.Name)
           continue;
-        std::vector<PersistentDeclRef<Decl>> Output;
+        std::vector<Indexed<PersistentDeclRef<Decl>>> Output;
         for (const auto &ResultTuple :
              zip(DQ->getInputs(), PredicateResult.IntegerValues)) {
           const Decl *D = std::get<0>(ResultTuple);
           int Result = std::get<1>(ResultTuple);
-          Output.push_back(PersistentDeclRef<Decl>::create(
-              (IsNot ? !Result : !!Result) ? D : nullptr));
+          bool Value = (IsNot ? !Result : !!Result);
+          Output.push_back(Indexed<PersistentDeclRef<Decl>>(
+              PersistentDeclRef<Decl>::create(Value ? D : nullptr),
+              Value ? QueryBoolResult::Yes : QueryBoolResult::No));
         }
         DQ->setOutput(std::move(Output));
         break;

--- a/lib/Tooling/Refactor/RefactoringContinuations.h
+++ b/lib/Tooling/Refactor/RefactoringContinuations.h
@@ -188,7 +188,7 @@ public:
     // with them by itself.
     for (const auto &Ref : Refs)
       Results.push_back(indexer::Indexed<const T *>(
-          dyn_cast_or_null<T>(lookupDecl(Ref.Decl.USR)), Ref.BoolResult));
+          dyn_cast_or_null<T>(lookupDecl(Ref.Decl.USR)), Ref.IsNotDefined));
     return Results;
   }
 

--- a/lib/Tooling/Refactor/RefactoringContinuations.h
+++ b/lib/Tooling/Refactor/RefactoringContinuations.h
@@ -61,8 +61,13 @@ struct StateTraits<ArrayRef<const T *>>
 template <typename T>
 struct StateTraits<std::unique_ptr<indexer::ManyToManyDeclarationsQuery<T>>>
     : std::enable_if<std::is_base_of<Decl, T>::value, ValidBase>::type {
-  using StoredResultType = std::vector<const T *>;
-  using PersistentType = std::vector<PersistentDeclRef<T>>;
+  using StoredResultType = std::vector<indexer::Indexed<const T *>>;
+  using PersistentType = std::vector<indexer::Indexed<PersistentDeclRef<T>>>;
+};
+
+template <> struct StateTraits<std::vector<std::string>> {
+  using StoredResultType = std::vector<std::string>;
+  using PersistentType = std::vector<std::string>;
 };
 
 /// Conversion functions convert the TU-specific state to a TU independent
@@ -88,12 +93,18 @@ std::vector<PersistentDeclRef<T>> convertToPersistentRepresentation(
 }
 
 template <typename T>
-std::vector<PersistentDeclRef<T>> convertToPersistentRepresentation(
+std::vector<indexer::Indexed<PersistentDeclRef<T>>>
+convertToPersistentRepresentation(
     std::unique_ptr<indexer::ManyToManyDeclarationsQuery<T>> &Query,
     typename std::enable_if<std::is_base_of<Decl, T>::value>::type * =
         nullptr) {
   Query->invalidateTUSpecificState();
   return Query->getOutput();
+}
+
+inline std::vector<std::string>
+convertToPersistentRepresentation(const std::vector<std::string> &Values) {
+  return Values;
 }
 
 /// Converts the TU-independent state to the TU-specific state.
@@ -154,12 +165,45 @@ public:
     return Results;
   }
 
+  template <typename T>
+  bool addConvertible(
+      const std::vector<indexer::Indexed<PersistentDeclRef<T>>> &Refs,
+      typename std::enable_if<std::is_base_of<Decl, T>::value>::type * =
+          nullptr) {
+    for (const auto &Ref : Refs) {
+      if (!Ref.Decl.USR.empty())
+        ConvertedDeclRefs[Ref.Decl.USR] = nullptr;
+    }
+    return true;
+  }
+
+  template <typename T>
+  std::vector<indexer::Indexed<const T *>>
+  convert(const std::vector<indexer::Indexed<PersistentDeclRef<T>>> &Refs,
+          typename std::enable_if<std::is_base_of<Decl, T>::value>::type * =
+              nullptr) {
+    std::vector<indexer::Indexed<const T *>> Results;
+    Results.reserve(Refs.size());
+    // Allow nulls in the produced array, the continuation will have to deal
+    // with them by itself.
+    for (const auto &Ref : Refs)
+      Results.push_back(indexer::Indexed<const T *>(
+          dyn_cast_or_null<T>(lookupDecl(Ref.Decl.USR)), Ref.BoolResult));
+    return Results;
+  }
+
   bool addConvertible(const PersistentFileID &) {
     // Do nothing since FileIDs are converted one-by-one.
     return true;
   }
 
   FileID convert(const PersistentFileID &Ref);
+
+  bool addConvertible(const std::vector<std::string> &) { return true; }
+
+  std::vector<std::string> convert(const std::vector<std::string> &Values) {
+    return Values;
+  }
 
   /// Converts the added persistent state into TU-specific state using one
   /// efficient operation.

--- a/test/Refactor/ImplementDeclaredMethods/Inputs/objcClass.m
+++ b/test/Refactor/ImplementDeclaredMethods/Inputs/objcClass.m
@@ -11,3 +11,5 @@
 @end
 // CHECK1: "{{.*}}objcClass.m" "- (void)method { \n  <#code#>;\n}\n\n+ (void)classMethod { \n  <#code#>;\n}\n\n- (void)implementedMethod { \n  <#code#>;\n}\n\n- (void)method:(int)x with:(int)y { \n  <#code#>;\n}\n\n" [[@LINE-1]]:1 -> [[@LINE-1]]:1
 // CHECK2: "{{.*}}objcClass.m" "- (void)method { \n  <#code#>;\n}\n\n- (void)implementedMethod { \n  <#code#>;\n}\n\n" [[@LINE-2]]:1
+
+// CHECK-CAT-NO-IMPL: "{{.*}}objcClass.m" "- (void)thisCategoryMethodShouldBeInTheClassImplementation { \n  <#code#>;\n}\n\n" 11:1 -> 11:1

--- a/test/Refactor/ImplementDeclaredMethods/implement-declared-methods.m
+++ b/test/Refactor/ImplementDeclaredMethods/implement-declared-methods.m
@@ -77,3 +77,5 @@
 @end
 
 // RUN: clang-refactor-test perform -action implement-declared-methods -selected=category-no-impl -continuation-file=%s -query-results=query-all-impl %s | FileCheck --check-prefix=CHECK-CAT-NO-IMPL %s
+// It should work even in another TU!
+// RUN: clang-refactor-test perform -action implement-declared-methods -selected=category-no-impl -continuation-file=%S/Inputs/objcClass.m -query-results=query-all-impl %s | FileCheck --check-prefix=CHECK-CAT-NO-IMPL %S/Inputs/objcClass.m

--- a/tools/libclang/CRefactor.cpp
+++ b/tools/libclang/CRefactor.cpp
@@ -1024,7 +1024,7 @@ public:
   struct QueryWrapper {
     indexer::IndexerQuery *Query;
     CXTranslationUnit TU;
-    std::vector<PersistentDeclRef<Decl>> DeclResults;
+    std::vector<indexer::Indexed<PersistentDeclRef<Decl>>> DeclResults;
     unsigned ConsumedResults = 0;
 
     QueryWrapper(indexer::IndexerQuery *Query, CXTranslationUnit TU)
@@ -1884,13 +1884,18 @@ clang_IndexerQuery_consumeIntResult(CXIndexerQuery Query, unsigned CursorIndex,
     return CXIndexerQueryAction_None;
   if (Wrapper->DeclResults.empty())
     Wrapper->DeclResults.resize(DQ->getInputs().size(),
-                                PersistentDeclRef<Decl>::create(nullptr));
+                                indexer::Indexed<PersistentDeclRef<Decl>>(
+                                    PersistentDeclRef<Decl>::create(nullptr),
+                                    indexer::QueryBoolResult::Unknown));
   // Filter the declarations!
   bool IsNot = false;
   if (isa<indexer::detail::DeclPredicateNotPredicate>(DQ->getPredicateNode()))
     IsNot = true;
-  Wrapper->DeclResults[CursorIndex] = PersistentDeclRef<Decl>::create(
-      (IsNot ? !Value : !!Value) ? DQ->getInputs()[CursorIndex] : nullptr);
+  bool Result = IsNot ? !Value : !!Value;
+  Wrapper->DeclResults[CursorIndex] = indexer::Indexed<PersistentDeclRef<Decl>>(
+      PersistentDeclRef<Decl>::create(Result ? DQ->getInputs()[CursorIndex]
+                                             : nullptr),
+      Result ? indexer::QueryBoolResult::Yes : indexer::QueryBoolResult::No);
   Wrapper->ConsumedResults++;
   if (Wrapper->ConsumedResults == Wrapper->DeclResults.size()) {
     // We've received all the results, pass them back to the query.

--- a/tools/libclang/CRefactor.cpp
+++ b/tools/libclang/CRefactor.cpp
@@ -1885,8 +1885,7 @@ clang_IndexerQuery_consumeIntResult(CXIndexerQuery Query, unsigned CursorIndex,
   if (Wrapper->DeclResults.empty())
     Wrapper->DeclResults.resize(DQ->getInputs().size(),
                                 indexer::Indexed<PersistentDeclRef<Decl>>(
-                                    PersistentDeclRef<Decl>::create(nullptr),
-                                    indexer::QueryBoolResult::Unknown));
+                                    PersistentDeclRef<Decl>::create(nullptr)));
   // Filter the declarations!
   bool IsNot = false;
   if (isa<indexer::detail::DeclPredicateNotPredicate>(DQ->getPredicateNode()))


### PR DESCRIPTION
category methods into class implementation declarations even when
the category is not available in the TU in which the class is implemented

The previous PR at https://github.com/apple/swift-clang/pull/94 didn't take into account that the category might not be declared in the TU which has the classes implementation. The non-defined methods will resolve to NULL in that case and the operation won't actually create the method stubs. This patch ensures that method stubs are pre-generated in the initiation TU and that the result of the not-defined query is propagated to the continuation even when the method resolves to NULL (In a hacky way, but it will be improved in the new engine at llvm.org).

rdar://32875896