### PR TITLE
The "does not conform to protocol" -Wprotocol refactoring warning should take method availability into account

### DIFF
--- a/lib/Edit/FillInMissingProtocolStubs.cpp
+++ b/lib/Edit/FillInMissingProtocolStubs.cpp
@@ -139,6 +139,11 @@ public:
     for (const ObjCMethodDecl *M : P->methods()) {
       if (M->isImplicit())
         continue;
+      AvailabilityResult Availability = M->getAvailability();
+      // Methods that are unavailable or not yet introduced are not considered
+      // to be required.
+      if (Availability == AR_NotYetIntroduced || Availability == AR_Unavailable)
+        continue;
       auto &Map = M->isInstanceMethod() ? InstanceMethods : ClassMethods;
       Map.insert(std::make_pair(M->getSelector(), MethodInfo(M, P, Priority)));
     }

--- a/lib/Sema/SemaDeclObjC.cpp
+++ b/lib/Sema/SemaDeclObjC.cpp
@@ -2133,23 +2133,28 @@ void Sema::CheckImplementationIvars(ObjCImplementationDecl *ImpDecl,
     Diag(IVI->getLocation(), diag::err_inconsistent_ivar_count);
 }
 
-static void WarnUndefinedMethod(Sema &S, SourceLocation ImpLoc,
-                                ObjCMethodDecl *method,
-                                bool &IncompleteImpl,
-                                unsigned DiagID,
-                                NamedDecl *NeededFor = nullptr) {
+static bool shouldWarnUndefinedMethod(const ObjCMethodDecl *M) {
   // No point warning no definition of method which is 'unavailable'.
-  switch (method->getAvailability()) {
+  switch (M->getAvailability()) {
   case AR_Available:
   case AR_Deprecated:
-    break;
+    return true;
 
-      // Don't warn about unavailable or not-yet-introduced methods.
+  // Don't warn about unavailable or not-yet-introduced methods.
   case AR_NotYetIntroduced:
   case AR_Unavailable:
-    return;
+    return false;
   }
-  
+  llvm_unreachable("Invalid availability");
+}
+
+static void WarnUndefinedMethod(Sema &S, SourceLocation ImpLoc,
+                                ObjCMethodDecl *method, bool &IncompleteImpl,
+                                unsigned DiagID,
+                                NamedDecl *NeededFor = nullptr) {
+  if (!shouldWarnUndefinedMethod(method))
+    return;
+
   // FIXME: For now ignore 'IncompleteImpl'.
   // Previously we grouped all unimplemented methods under a single
   // warning, but some users strongly voiced that they would prefer
@@ -2706,7 +2711,9 @@ static void CheckProtocolMethodDefs(
             unsigned DIAG = diag::warn_unimplemented_protocol_method;
             if (!S.Diags.isIgnored(DIAG, ImpLoc)) {
               if (MissingRequirements)
-                HasMissingRequirements = true;
+                HasMissingRequirements =
+                    HasMissingRequirements ? true
+                                           : shouldWarnUndefinedMethod(method);
               else
                 WarnUndefinedMethod(S, ImpLoc, method, IncompleteImpl, DIAG,
                                     PDecl);
@@ -2732,7 +2739,8 @@ static void CheckProtocolMethodDefs(
       unsigned DIAG = diag::warn_unimplemented_protocol_method;
       if (!S.Diags.isIgnored(DIAG, ImpLoc)) {
         if (MissingRequirements)
-          HasMissingRequirements = true;
+          HasMissingRequirements =
+              HasMissingRequirements ? true : shouldWarnUndefinedMethod(method);
         else
           WarnUndefinedMethod(S, ImpLoc, method, IncompleteImpl, DIAG, PDecl);
       }

--- a/test/FixIt/fixit-fill-in-protocol-requirements.m
+++ b/test/FixIt/fixit-fill-in-protocol-requirements.m
@@ -1,5 +1,6 @@
-// RUN: %clang_cc1 -verify -Wno-objc-root-class -serialize-diagnostic-file /dev/null %s
-// RUN: %clang_cc1 -fdiagnostics-parseable-fixits -serialize-diagnostic-file /dev/null %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -triple=x86_64-apple-macos10.10 -verify -Wno-objc-root-class -serialize-diagnostic-file /dev/null %s
+// RUN: %clang_cc1 -triple=x86_64-apple-macos10.10 -fdiagnostics-parseable-fixits -serialize-diagnostic-file /dev/null %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -triple=x86_64-apple-macos10.12 -fdiagnostics-parseable-fixits -serialize-diagnostic-file /dev/null %s 2>&1 | FileCheck --check-prefix=AVAILABLE %s
 
 @protocol P1
 
@@ -52,3 +53,30 @@
 @end
 @implementation FourProtocols
 @end
+
+// Unavailable methods
+@protocol TakeAvailabilityIntoAccount
+
+- (void)unavailableMethod __attribute__((availability(macos,unavailable)));
++ (void)notYetAvailableMethod __attribute__((availability(macos,introduced=10.11)));
+- (void)availableMethod;
+
+@end
+
+@interface ImplementsAllAvailable <TakeAvailabilityIntoAccount>
+@end
+
+@implementation ImplementsAllAvailable // No warning!
+
+- (void)availableMethod { }
+
+@end
+
+@interface FixitJustAvailable <TakeAvailabilityIntoAccount>
+@end
+
+@implementation FixitJustAvailable // expected-warning {{class 'FixitJustAvailable' does not conform to protocol 'TakeAvailabilityIntoAccount'}} expected-note {{add stubs for missing protocol requirements}}
+
+@end
+// CHECK: fix-it:{{.*}}:{[[@LINE-1]]:1-[[@LINE-1]]:1}:"- (void)availableMethod { \n  <#code#>\n}\n\n"
+// AVAILABLE: fix-it:{{.*}}:{[[@LINE-2]]:1-[[@LINE-2]]:1}:"- (void)availableMethod { \n  <#code#>\n}\n\n+ (void)notYetAvailableMethod { \n  <#code#>\n}\n\n"


### PR DESCRIPTION
This also ensures that the "Add missing requirements"
refactoring action doesn't add stubs for methods that
are unavailable or not yet introduced.

rdar://32549953