### PR TITLE
[refactor][extract] fix crash

### DIFF
--- a/lib/Tooling/Refactor/Extract.cpp
+++ b/lib/Tooling/Refactor/Extract.cpp
@@ -161,6 +161,22 @@ static bool isMultipleCandidateBinOp(BinaryOperatorKind Op) {
   return Op == BO_Add || Op == BO_Sub;
 }
 
+/// Searches for the selected statement in the given CompoundStatement, looking
+/// through things like PseudoObjectExpressions.
+static CompoundStmt::const_body_iterator
+findSelectedStmt(CompoundStmt::body_const_range Statements,
+                 const Stmt *Target) {
+  return llvm::find_if(Statements, [=](const Stmt *S) {
+    if (S == Target)
+      return true;
+    if (const auto *POE = dyn_cast<PseudoObjectExpr>(S)) {
+      if (POE->getSyntacticForm() == Target)
+        return true;
+    }
+    return false;
+  });
+}
+
 /// Returns the first and the last statements that should be extracted from a
 /// compound statement.
 Optional<CompoundStatementRange> getExtractedStatements(const CompoundStmt *CS,
@@ -170,9 +186,10 @@ Optional<CompoundStatementRange> getExtractedStatements(const CompoundStmt *CS,
     return None;
   assert(Begin && End);
   CompoundStatementRange Result;
-  Result.First = std::find(CS->body_begin(), CS->body_end(), Begin);
+  Result.First = findSelectedStmt(CS->body(), Begin);
   assert(Result.First != CS->body_end());
-  Result.Last = std::find(Result.First, CS->body_end(), End);
+  Result.Last = findSelectedStmt(
+      CompoundStmt::body_const_range(Result.First, CS->body_end()), End);
   assert(Result.Last != CS->body_end());
   return Result;
 }

--- a/test/Refactor/Extract/extract-objc-property.m
+++ b/test/Refactor/Extract/extract-objc-property.m
@@ -45,3 +45,16 @@
 // RUN: not clang-refactor-test initiate -action extract -selected=setter -selected=setter-pref -selected=implicit-setter -selected=implicit-setter-pref %s -fobjc-arc 2>&1 | FileCheck --check-prefix=CHECK-SETTER %s
 
 @end
+
+@interface HasIntProp
+@property (readwrite) int item;
+@end
+
+// AVOID-CRASH: "static void extracted(HasIntProp *f) {\nf.item = !f.item;\n}\n\n"
+// avoid-extraction-crash-begin: +1:42
+void avoidExtractionCrash(HasIntProp *f) {
+  f.item = !f.item;
+// avoid-extraction-crash-end: -1:5
+}
+
+// RUN: clang-refactor-test perform -action extract -selected=avoid-extraction-crash %s -fobjc-arc | FileCheck --check-prefix=AVOID-CRASH %s


### PR DESCRIPTION
We didn't find the begin/end statements in the CS sometimes when selecting ObjC properties because of PseudoObjectExpr