### PR TITLE
Fix Windows support for Driver and add support to Index

### DIFF
--- a/include/clang/Index/IndexDataStore.h
+++ b/include/clang/Index/IndexDataStore.h
@@ -38,7 +38,7 @@ public:
   struct Event {
     EventKind Kind;
     std::string Filename;
-    timespec ModTime;
+    time_t ModTime;
   };
 
   typedef std::function<void(ArrayRef<Event> Events, bool isInitial)> EventReceiver;
@@ -71,7 +71,7 @@ public:
   struct UnitEvent {
     UnitEventKind Kind;
     StringRef UnitName;
-    timespec ModTime;
+    time_t ModTime;
   };
   struct UnitEventNotification {
     bool IsInitial;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -37,7 +37,10 @@
 #include "llvm/Support/raw_ostream.h"
 #include <cstdlib> // ::getenv
 #include <system_error>
+
+#if !defined(_WIN32)
 #include <sys/utsname.h>
+#endif
 
 using namespace clang::driver;
 using namespace clang::driver::toolchains;
@@ -511,6 +514,7 @@ void DarwinClang::AddLinkRuntimeLibArgs(const ArgList &Args,
   }
 }
 
+#if !defined(_WIN32)
 // Clang-900 specific change that's cherry-picked from the LLVM change r307372:
 static std::string getOSVersion() {
   struct utsname info;
@@ -560,6 +564,7 @@ static std::string getSystemOrSDKMacOSVersion(StringRef MacOSSDKVersion) {
     return SystemVersion.getAsString();
   return MacOSSDKVersion;
 }
+#endif // defined(_WIN32)
 
 void Darwin::AddDeploymentTarget(DerivedArgList &Args) const {
   const OptTable &Opts = getDriver().getOpts();
@@ -672,7 +677,11 @@ void Darwin::AddDeploymentTarget(DerivedArgList &Args) const {
                 SDK.startswith("iPhoneSimulator"))
               iOSTarget = Version;
             else if (SDK.startswith("MacOSX"))
-              OSXTarget = getSystemOrSDKMacOSVersion(Version);
+#if !defined(_WIN32)
+              OSXTarget = getSystemOrSDKMacOSVersion(Version)
+#else
+              OSXTarget = Version;
+#endif
             else if (SDK.startswith("WatchOS") ||
                      SDK.startswith("WatchSimulator"))
               WatchOSTarget = Version;

--- a/lib/Index/IndexUnitReader.cpp
+++ b/lib/Index/IndexUnitReader.cpp
@@ -21,7 +21,11 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 
+#if defined(_WIN32)
+#include <io.h>
+#else 
 #include <unistd.h>
+#endif
 
 using namespace clang;
 using namespace clang::index;
@@ -400,7 +404,11 @@ IndexUnitReader::createWithFilePath(StringRef FilePath, std::string &Error) {
     int FD;
     AutoFDClose(int FD) : FD(FD) {}
     ~AutoFDClose() {
+      #if defined(_WIN32)
+      _close(FD);
+      #else
       ::close(FD);
+      #endif
     }
   } AutoFDClose(FD);
 


### PR DESCRIPTION
This pull request contains fixes to enable Clang to build on Windows against the MSVC toolchain. 

Of particular note is the change from timespec to time_t in IndexDataStore.h; this field doesn't seem to be in use, and time_t is consistent with elsewhere in the repository, but the two types are not equivalent, so I'm not certain this change is correct.

I also if-blocked out some Unix specific APIs around getting the system SDK.