### PR TITLE
Soft-deprecate -fapinotes-cache-path; use -fmodules-cache-path instead.

### DIFF
--- a/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -230,7 +230,7 @@ def err_invalid_vfs_overlay : Error<
   "invalid virtual filesystem overlay file '%0'">, DefaultFatal;
 
 def err_no_apinotes_cache_path : Error<
-  "-fapinotes was provided without -fapinotes-cache-path=<directory>">,
+  "-fapinotes was provided without -fmodules-cache-path=<directory>">,
   DefaultFatal;
 
 def warn_option_invalid_ocl_version : Warning<

--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -719,7 +719,7 @@ def fno_apinotes_modules : Flag<["-"], "fno-apinotes-modules">, Group<f_clang_Gr
   Flags<[CC1Option]>, HelpText<"Disable module-based external API notes support">;
 def fapinotes_cache_path : Joined<["-"], "fapinotes-cache-path=">,
   Group<i_Group>, Flags<[DriverOption, CC1Option]>, MetaVarName<"<directory>">,
-  HelpText<"Specify the API notes cache path">;
+  HelpText<"Specify the API notes cache path (defaults to -fmodules-cache-path)">;
 def fapinotes_swift_version : Joined<["-"], "fapinotes-swift-version=">,
   Group<f_clang_Group>, Flags<[CC1Option]>, MetaVarName<"<version>">,
   HelpText<"Specify the Swift version to use when filtering API notes">;

--- a/lib/Driver/ToolChains/Clang.cpp
+++ b/lib/Driver/ToolChains/Clang.cpp
@@ -3985,27 +3985,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                      options::OPT_fno_apinotes_modules, false))
       CmdArgs.push_back("-fapinotes-modules");
 
-    SmallString<128> APINotesCachePath;
     if (Arg *A = Args.getLastArg(options::OPT_fapinotes_cache_path)) {
-      APINotesCachePath = A->getValue();
+      SmallString<128> APINotesCachePath{"-fapinotes-cache-path="};
+      APINotesCachePath += A->getValue();
+      CmdArgs.push_back(Args.MakeArgString(APINotesCachePath));
     }
-
-    if (C.isForDiagnostics()) {
-      // When generating crash reports, we want to emit the API notes along with
-      // the reproduction sources, so we ignore any provided API notes path.
-      APINotesCachePath = Output.getFilename();
-      llvm::sys::path::replace_extension(APINotesCachePath, ".cache");
-      llvm::sys::path::append(APINotesCachePath, "apinotes");
-    } else if (APINotesCachePath.empty()) {
-      // No API notes path was provided: use the default.
-      llvm::sys::path::system_temp_directory(/*erasedOnReboot=*/false,
-                                             APINotesCachePath);
-      llvm::sys::path::append(APINotesCachePath, "org.llvm.clang");
-      llvm::sys::path::append(APINotesCachePath, "APINotesCache");
-    }
-    const char Arg[] = "-fapinotes-cache-path=";
-    APINotesCachePath.insert(APINotesCachePath.begin(), Arg, Arg + strlen(Arg));
-    CmdArgs.push_back(Args.MakeArgString(APINotesCachePath));
 
     Args.AddLastArg(CmdArgs, options::OPT_fapinotes_swift_version);
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2731,11 +2731,16 @@ bool CompilerInvocation::CreateFromArgs(CompilerInvocation &Res,
     if (Res.getFrontendOpts().ProgramAction == frontend::RewriteObjC)
       LangOpts.ObjCExceptions = 1;
 
-    // -fapinotes and -fapinotes-modules requires -fapinotes-cache-path=<directory>.
+    // -fapinotes and -fapinotes-modules requires -fmodules-cache-path=<directory>.
     if ((LangOpts.APINotes || LangOpts.APINotesModules) &&
         Res.getFileSystemOpts().APINotesCachePath.empty()) {
-      Diags.Report(diag::err_no_apinotes_cache_path);
-      Success = false;
+      if (!Res.getHeaderSearchOpts().ModuleCachePath.empty()) {
+        Res.getFileSystemOpts().APINotesCachePath =
+            Res.getHeaderSearchOpts().ModuleCachePath;
+      } else {
+        Diags.Report(diag::err_no_apinotes_cache_path);
+        Success = false;
+      }
     }
   }
 

--- a/test/APINotes/cache.m
+++ b/test/APINotes/cache.m
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t/APINotesCache
+// RUN: rm -rf %t
 // RUN: %clang_cc1 -fapinotes -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -verify
 
 // Check for the presence of the cached compiled form.
@@ -6,11 +6,19 @@
 // RUN: ls %t/APINotesCache | grep "SomeKit-.*.apinotesc"
 
 // Run test again to ensure that caching doesn't cause problems.
-// RUN: %clang_cc1 -fapinotes -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -I %S/Inputs/Headers -F %S/Inputs/Frameworks  %s -verify
+// RUN: %clang_cc1 -fapinotes -fapinotes-modules -fapinotes-cache-path=%t/APINotesCache -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -verify
 
-// Check that the driver provides a default -fapinotes-cache-path=
+// Check that the default path is taken from -fmodules-cache-path.
+// RUN: %clang_cc1 -fapinotes -fapinotes-modules -fmodules-cache-path=%t/ModuleCache -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -verify
+// RUN: ls %t/ModuleCache | grep "APINotes-.*.apinotesc"
+// RUN: ls %t/ModuleCache | grep "SomeKit-.*.apinotesc"
+
+// RUN: not %clang_cc1 -fapinotes -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s 2>&1 | FileCheck --check-prefix=CHECK-NO-CACHE %s
+// CHECK-NO-CACHE: error: -fapinotes was provided without -fmodules-cache-path
+
+// Check that the driver does not provide a default -fapinotes-cache-path=.
 // RUN: %clang -fsyntax-only -fapinotes -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -### 2>&1 | FileCheck --check-prefix=CHECK-DEFAULT-PATH %s
-// CHECK-DEFAULT-PATH: -fapinotes-cache-path={{.*}}org.llvm.clang/APINotesCache
+// CHECK-DEFAULT-PATH-NOT: -fapinotes-cache-path
 
 // Check that the driver passes through a provided -fapinotes-cache-path=
 // RUN: %clang -fsyntax-only -fapinotes -fapinotes-modules -fapinotes-cache-path=/wobble -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -### 2>&1 | FileCheck --check-prefix=CHECK-PATH %s


### PR DESCRIPTION
When Clang decided to change the default module cache path to include the current user's name, the API notes path didn't change. Rather than duplicate that logic, just put the API notes cache in with the module cache by default. We still support -fapinotes-cache-path in case anyone's using it, but from now on -fmodules-cache-path should be sufficient. (This is reasonable because API notes are currently linked to modules anyway.)

[SR-5806](https://bugs.swift.org/browse/SR-5806)