### PR TITLE
Fix Windows support for Driver and add support to Index

### DIFF
--- a/include/clang/Index/IndexDataStore.h
+++ b/include/clang/Index/IndexDataStore.h
@@ -38,7 +38,7 @@ public:
   struct Event {
     EventKind Kind;
     std::string Filename;
-    timespec ModTime;
+    time_t ModTime;
   };
 
   typedef std::function<void(ArrayRef<Event> Events, bool isInitial)> EventReceiver;
@@ -71,7 +71,7 @@ public:
   struct UnitEvent {
     UnitEventKind Kind;
     StringRef UnitName;
-    timespec ModTime;
+    time_t ModTime;
   };
   struct UnitEventNotification {
     bool IsInitial;

--- a/include/clang/Index/IndexDataStore.h
+++ b/include/clang/Index/IndexDataStore.h
@@ -14,6 +14,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Chrono.h"
 #include <functional>
 #include <memory>
 #include <string>
@@ -38,7 +39,7 @@ public:
   struct Event {
     EventKind Kind;
     std::string Filename;
-    time_t ModTime;
+    llvm::sys::TimePoint<> ModTime;
   };
 
   typedef std::function<void(ArrayRef<Event> Events, bool isInitial)> EventReceiver;
@@ -71,7 +72,7 @@ public:
   struct UnitEvent {
     UnitEventKind Kind;
     StringRef UnitName;
-    time_t ModTime;
+    llvm::sys::TimePoint<> ModTime;
   };
   struct UnitEventNotification {
     bool IsInitial;

--- a/lib/DirectoryWatcher/DirectoryWatcher.cpp
+++ b/lib/DirectoryWatcher/DirectoryWatcher.cpp
@@ -31,18 +31,6 @@
 using namespace clang;
 using namespace llvm;
 
-static timespec toTimeSpec(sys::TimePoint<> tp) {
-  std::chrono::seconds sec = std::chrono::time_point_cast<std::chrono::seconds>(
-                 tp).time_since_epoch();
-  std::chrono::nanoseconds nsec =
-    std::chrono::time_point_cast<std::chrono::nanoseconds>(tp - sec)
-      .time_since_epoch();
-  timespec ts;
-  ts.tv_sec = sec.count();
-  ts.tv_nsec = nsec.count();
-  return ts;
-}
-
 static Optional<llvm::sys::TimePoint<>> getModTime(StringRef path) {
   sys::fs::file_status Status;
   std::error_code EC = status(path, Status);

--- a/lib/Index/IndexUnitReader.cpp
+++ b/lib/Index/IndexUnitReader.cpp
@@ -21,7 +21,11 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 
+#if defined(_WIN32)
+#include <io.h>
+#else 
 #include <unistd.h>
+#endif
 
 using namespace clang;
 using namespace clang::index;
@@ -400,7 +404,11 @@ IndexUnitReader::createWithFilePath(StringRef FilePath, std::string &Error) {
     int FD;
     AutoFDClose(int FD) : FD(FD) {}
     ~AutoFDClose() {
+      #if defined(_WIN32)
+      _close(FD);
+      #else
       ::close(FD);
+      #endif
     }
   } AutoFDClose(FD);
 

--- a/lib/Index/IndexUnitReader.cpp
+++ b/lib/Index/IndexUnitReader.cpp
@@ -19,6 +19,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/Process.h"
 #include "llvm/Support/raw_ostream.h"
 
 #if defined(_WIN32)
@@ -404,11 +405,7 @@ IndexUnitReader::createWithFilePath(StringRef FilePath, std::string &Error) {
     int FD;
     AutoFDClose(int FD) : FD(FD) {}
     ~AutoFDClose() {
-      #if defined(_WIN32)
-      _close(FD);
-      #else
-      ::close(FD);
-      #endif
+        llvm::sys::Process::SafelyCloseFileDescriptor(FD);
     }
   } AutoFDClose(FD);
 

--- a/lib/Index/IndexUnitReader.cpp
+++ b/lib/Index/IndexUnitReader.cpp
@@ -22,9 +22,7 @@
 #include "llvm/Support/Process.h"
 #include "llvm/Support/raw_ostream.h"
 
-#if defined(_WIN32)
-#include <io.h>
-#else 
+#if !defined(_WIN32)
 #include <unistd.h>
 #endif
 

--- a/lib/Index/IndexUnitReader.cpp
+++ b/lib/Index/IndexUnitReader.cpp
@@ -22,10 +22,6 @@
 #include "llvm/Support/Process.h"
 #include "llvm/Support/raw_ostream.h"
 
-#if !defined(_WIN32)
-#include <unistd.h>
-#endif
-
 using namespace clang;
 using namespace clang::index;
 using namespace clang::index::store;

--- a/tools/IndexStore/IndexStore.cpp
+++ b/tools/IndexStore/IndexStore.cpp
@@ -139,7 +139,7 @@ indexstore_unit_event_get_unit_name(indexstore_unit_event_t c_evt) {
 timespec
 indexstore_unit_event_get_modification_time(indexstore_unit_event_t c_evt) {
   auto *evt = static_cast<IndexDataStore::UnitEvent*>(c_evt);
-  return evt->ModTime;
+  return toTimeSpec(evt->ModTime);
 }
 
 void


### PR DESCRIPTION
This pull request contains fixes to enable Clang to build on Windows against the MSVC toolchain.

Of particular note is the change from timespec to time_t in IndexDataStore.h; this field doesn't seem to be in use, and time_t is consistent with elsewhere in the repository, but the two types are not equivalent, so I'm not certain this change is correct.

https://github.com/apple/swift-clang/pull/113 rebased off upstream-with-swift