### PR TITLE
[APINotes] Add 'RetainCountConvention'

### DIFF
--- a/include/clang/APINotes/Types.h
+++ b/include/clang/APINotes/Types.h
@@ -46,6 +46,15 @@ public:
   explicit ContextID(unsigned value) : Value(value) { }
 };
 
+enum class RetainCountConventionKind {
+  None,
+  CFReturnsRetained,
+  CFReturnsNotRetained,
+  NSReturnsRetained,
+  NSReturnsNotRetained,
+};
+
+
 /// Describes API notes data for any entity.
 ///
 /// This is used as the base of all API notes.
@@ -447,8 +456,14 @@ class ParamInfo : public VariableInfo {
   /// Whether the this parameter has the 'noescape' attribute.
   unsigned NoEscape : 1;
 
+  /// A biased RetainCountConventionKind, where 0 means "unspecified".
+  ///
+  /// Only relevant for out-parameters.
+  unsigned RawRetainCountConvention : 3;
+
 public:
-  ParamInfo() : VariableInfo(), NoEscapeSpecified(false), NoEscape(false) { }
+  ParamInfo() : VariableInfo(), NoEscapeSpecified(false), NoEscape(false),
+      RawRetainCountConvention() { }
 
   Optional<bool> isNoEscape() const {
     if (!NoEscapeSpecified) return None;
@@ -464,19 +479,35 @@ public:
     }
   }
 
+  Optional<RetainCountConventionKind> getRetainCountConvention() const {
+    if (!RawRetainCountConvention)
+      return None;
+    return static_cast<RetainCountConventionKind>(RawRetainCountConvention - 1);
+  }
+  void setRetainCountConvention(Optional<RetainCountConventionKind> convention){
+    if (convention)
+      RawRetainCountConvention = static_cast<unsigned>(convention.getValue())+1;
+    else
+      RawRetainCountConvention = 0;
+    assert(getRetainCountConvention() == convention && "bitfield too small");
+  }
+
   friend ParamInfo &operator|=(ParamInfo &lhs, const ParamInfo &rhs) {
     static_cast<VariableInfo &>(lhs) |= rhs;
     if (!lhs.NoEscapeSpecified && rhs.NoEscapeSpecified) {
       lhs.NoEscapeSpecified = true;
       lhs.NoEscape = rhs.NoEscape;
     }
+    if (!lhs.RawRetainCountConvention)
+      lhs.RawRetainCountConvention = rhs.RawRetainCountConvention;
     return lhs;
   }
 
   friend bool operator==(const ParamInfo &lhs, const ParamInfo &rhs) {
     return static_cast<const VariableInfo &>(lhs) == rhs &&
            lhs.NoEscapeSpecified == rhs.NoEscapeSpecified &&
-           lhs.NoEscape == rhs.NoEscape;
+           lhs.NoEscape == rhs.NoEscape &&
+           lhs.RawRetainCountConvention == rhs.RawRetainCountConvention;
   }
 
   friend bool operator!=(const ParamInfo &lhs, const ParamInfo &rhs) {
@@ -511,6 +542,9 @@ public:
   /// Number of types whose nullability is encoded with the NullabilityPayload.
   unsigned NumAdjustedNullable : 8;
 
+  /// A biased RetainCountConventionKind, where 0 means "unspecified".
+  unsigned RawRetainCountConvention : 3;
+
   /// Stores the nullability of the return type and the parameters.
   //  NullabilityKindSize bits are used to encode the nullability. The info
   //  about the return type is stored at position 0, followed by the nullability
@@ -526,7 +560,8 @@ public:
   FunctionInfo()
     : CommonEntityInfo(),
       NullabilityAudited(false),
-      NumAdjustedNullable(0) { }
+      NumAdjustedNullable(0),
+      RawRetainCountConvention() { }
 
   static unsigned getMaxNullabilityIndex() {
     return ((sizeof(NullabilityPayload) * CHAR_BIT)/NullabilityKindSize);
@@ -579,13 +614,27 @@ public:
     return getTypeInfo(0);
   }
 
+  Optional<RetainCountConventionKind> getRetainCountConvention() const {
+    if (!RawRetainCountConvention)
+      return None;
+    return static_cast<RetainCountConventionKind>(RawRetainCountConvention - 1);
+  }
+  void setRetainCountConvention(Optional<RetainCountConventionKind> convention){
+    if (convention)
+      RawRetainCountConvention = static_cast<unsigned>(convention.getValue())+1;
+    else
+      RawRetainCountConvention = 0;
+    assert(getRetainCountConvention() == convention && "bitfield too small");
+  }
+
   friend bool operator==(const FunctionInfo &lhs, const FunctionInfo &rhs) {
     return static_cast<const CommonEntityInfo &>(lhs) == rhs &&
            lhs.NullabilityAudited == rhs.NullabilityAudited &&
            lhs.NumAdjustedNullable == rhs.NumAdjustedNullable &&
            lhs.NullabilityPayload == rhs.NullabilityPayload &&
            lhs.ResultType == rhs.ResultType &&
-           lhs.Params == rhs.Params;
+           lhs.Params == rhs.Params &&
+           lhs.RawRetainCountConvention == rhs.RawRetainCountConvention;
   }
 
   friend bool operator!=(const FunctionInfo &lhs, const FunctionInfo &rhs) {

--- a/lib/APINotes/APINotesWriter.cpp
+++ b/lib/APINotes/APINotesWriter.cpp
@@ -724,6 +724,10 @@ namespace {
       if (*noescape)
         payload |= 0x02;
     }
+    payload <<= 3;
+    if (auto retainCountConvention = info.getRetainCountConvention()) {
+      payload |= static_cast<uint8_t>(retainCountConvention.getValue()) + 1;
+    }
     writer.write<uint8_t>(payload);
   }
 
@@ -744,7 +748,15 @@ namespace {
     emitCommonEntityInfo(out, info);
 
     endian::Writer<little> writer(out);
-    writer.write<uint8_t>(info.NullabilityAudited);
+
+    uint8_t payload = 0;
+    payload |= info.NullabilityAudited;
+    payload <<= 3;
+    if (auto retainCountConvention = info.getRetainCountConvention()) {
+      payload |= static_cast<uint8_t>(retainCountConvention.getValue()) + 1;
+    }
+    writer.write<uint8_t>(payload);
+
     writer.write<uint8_t>(info.NumAdjustedNullable);
     writer.write<uint64_t>(info.NullabilityPayload);
 

--- a/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -187,7 +187,8 @@ namespace {
   struct Param {
     unsigned Position;
     Optional<bool> NoEscape = false;
-    llvm::Optional<NullabilityKind> Nullability;
+    Optional<NullabilityKind> Nullability;
+    Optional<api_notes::RetainCountConventionKind> RetainCountConvention;
     StringRef Type;
   };
   typedef std::vector<Param> ParamsSeq;
@@ -197,7 +198,8 @@ namespace {
     MethodKind Kind;
     ParamsSeq Params;
     NullabilitySeq Nullability;
-    llvm::Optional<NullabilityKind> NullabilityOfRet;
+    Optional<NullabilityKind> NullabilityOfRet;
+    Optional<api_notes::RetainCountConventionKind> RetainCountConvention;
     AvailabilityItem Availability;
     Optional<bool> SwiftPrivate;
     StringRef SwiftName;
@@ -239,7 +241,8 @@ namespace {
     StringRef Name;
     ParamsSeq Params;
     NullabilitySeq Nullability;
-    llvm::Optional<NullabilityKind> NullabilityOfRet;
+    Optional<NullabilityKind> NullabilityOfRet;
+    Optional<api_notes::RetainCountConventionKind> RetainCountConvention;
     AvailabilityItem Availability;
     Optional<bool> SwiftPrivate;
     StringRef SwiftName;
@@ -409,6 +412,23 @@ namespace llvm {
       }
     };
 
+    template<>
+    struct ScalarEnumerationTraits<api_notes::RetainCountConventionKind> {
+      static void enumeration(IO &io,
+                              api_notes::RetainCountConventionKind &value) {
+        using api_notes::RetainCountConventionKind;
+        io.enumCase(value, "none", RetainCountConventionKind::None);
+        io.enumCase(value, "CFReturnsRetained",
+                    RetainCountConventionKind::CFReturnsRetained);
+        io.enumCase(value, "CFReturnsNotRetained",
+                    RetainCountConventionKind::CFReturnsNotRetained);
+        io.enumCase(value, "NSReturnsRetained",
+                    RetainCountConventionKind::NSReturnsRetained);
+        io.enumCase(value, "NSReturnsNotRetained",
+                    RetainCountConventionKind::NSReturnsNotRetained);
+      }
+    };
+
     template <>
     struct ScalarTraits<VersionTuple> {
       static void output(const VersionTuple &value, void*,
@@ -430,11 +450,12 @@ namespace llvm {
     template <>
     struct MappingTraits<Param> {
       static void mapping(IO &io, Param& p) {
-        io.mapRequired("Position",        p.Position);
-        io.mapOptional("Nullability",     p.Nullability, 
-                                          AbsentNullability);
-        io.mapOptional("NoEscape",        p.NoEscape);
-        io.mapOptional("Type",            p.Type, StringRef(""));
+        io.mapRequired("Position",              p.Position);
+        io.mapOptional("Nullability",           p.Nullability, 
+                                                AbsentNullability);
+        io.mapOptional("RetainCountConvention", p.RetainCountConvention);
+        io.mapOptional("NoEscape",              p.NoEscape);
+        io.mapOptional("Type",                  p.Type, StringRef(""));
       }
     };
 
@@ -457,21 +478,22 @@ namespace llvm {
     template <>
     struct MappingTraits<Method> {
       static void mapping(IO &io, Method& m) {
-        io.mapRequired("Selector",        m.Selector);
-        io.mapRequired("MethodKind",      m.Kind);
-        io.mapOptional("Parameters",      m.Params);
-        io.mapOptional("Nullability",     m.Nullability);
-        io.mapOptional("NullabilityOfRet",  m.NullabilityOfRet,
-                                            AbsentNullability);
-        io.mapOptional("Availability",    m.Availability.Mode);
-        io.mapOptional("AvailabilityMsg", m.Availability.Msg);
-        io.mapOptional("SwiftPrivate",    m.SwiftPrivate);
-        io.mapOptional("SwiftName",       m.SwiftName);
-        io.mapOptional("FactoryAsInit",   m.FactoryAsInit,
-                                          FactoryAsInitKind::Infer);
-        io.mapOptional("DesignatedInit",  m.DesignatedInit, false);
-        io.mapOptional("Required",        m.Required, false);
-        io.mapOptional("ResultType",      m.ResultType, StringRef(""));
+        io.mapRequired("Selector",              m.Selector);
+        io.mapRequired("MethodKind",            m.Kind);
+        io.mapOptional("Parameters",            m.Params);
+        io.mapOptional("Nullability",           m.Nullability);
+        io.mapOptional("NullabilityOfRet",      m.NullabilityOfRet,
+                                                AbsentNullability);
+        io.mapOptional("RetainCountConvention", m.RetainCountConvention);
+        io.mapOptional("Availability",          m.Availability.Mode);
+        io.mapOptional("AvailabilityMsg",       m.Availability.Msg);
+        io.mapOptional("SwiftPrivate",          m.SwiftPrivate);
+        io.mapOptional("SwiftName",             m.SwiftName);
+        io.mapOptional("FactoryAsInit",         m.FactoryAsInit,
+                                                FactoryAsInitKind::Infer);
+        io.mapOptional("DesignatedInit",        m.DesignatedInit, false);
+        io.mapOptional("Required",              m.Required, false);
+        io.mapOptional("ResultType",            m.ResultType, StringRef(""));
       }
     };
 
@@ -496,16 +518,17 @@ namespace llvm {
     template <>
     struct MappingTraits<Function> {
       static void mapping(IO &io, Function& f) {
-        io.mapRequired("Name",             f.Name);
-        io.mapOptional("Parameters",       f.Params);
-        io.mapOptional("Nullability",      f.Nullability);
-        io.mapOptional("NullabilityOfRet", f.NullabilityOfRet,
-                                           AbsentNullability);
-        io.mapOptional("Availability",     f.Availability.Mode);
-        io.mapOptional("AvailabilityMsg",  f.Availability.Msg);
-        io.mapOptional("SwiftPrivate",     f.SwiftPrivate);
-        io.mapOptional("SwiftName",        f.SwiftName);
-        io.mapOptional("ResultType",       f.ResultType, StringRef(""));
+        io.mapRequired("Name",                  f.Name);
+        io.mapOptional("Parameters",            f.Params);
+        io.mapOptional("Nullability",           f.Nullability);
+        io.mapOptional("NullabilityOfRet",      f.NullabilityOfRet,
+                                                AbsentNullability);
+        io.mapOptional("RetainCountConvention", f.RetainCountConvention);
+        io.mapOptional("Availability",          f.Availability.Mode);
+        io.mapOptional("AvailabilityMsg",       f.Availability.Msg);
+        io.mapOptional("SwiftPrivate",          f.SwiftPrivate);
+        io.mapOptional("SwiftName",             f.SwiftName);
+        io.mapOptional("ResultType",            f.ResultType, StringRef(""));
       }
     };
 
@@ -681,6 +704,7 @@ namespace {
           pi.setNullabilityAudited(*p.Nullability);
         pi.setNoEscape(p.NoEscape);
         pi.setType(p.Type);
+        pi.setRetainCountConvention(p.RetainCountConvention);
         while (outInfo.Params.size() <= p.Position) {
           outInfo.Params.push_back(ParamInfo());
         }
@@ -781,6 +805,8 @@ namespace {
       // Translate nullability info.
       convertNullability(meth.Nullability, meth.NullabilityOfRet,
                          mInfo, meth.Selector);
+
+      mInfo.setRetainCountConvention(meth.RetainCountConvention);
 
       // Write it.
       Writer->addObjCMethod(classID, selectorRef,
@@ -936,6 +962,7 @@ namespace {
                            function.NullabilityOfRet,
                            info, function.Name);
         info.ResultType = function.ResultType;
+        info.setRetainCountConvention(function.RetainCountConvention);
         Writer->addGlobalFunction(function.Name, info, swiftVersion);
       }
 
@@ -1218,6 +1245,7 @@ namespace {
         p.Nullability = pi.getNullability();
         p.NoEscape = pi.isNoEscape();
         p.Type = copyString(pi.getType());
+        p.RetainCountConvention = pi.getRetainCountConvention();
         params.push_back(p);
       }
     }
@@ -1287,6 +1315,7 @@ namespace {
       method.DesignatedInit = info.DesignatedInit;
       method.Required = info.Required;
       method.ResultType = copyString(info.ResultType);
+      method.RetainCountConvention = info.getRetainCountConvention();
       auto &items = getTopLevelItems(swiftVersion);
       knownContexts[contextID.Value].getContext(swiftVersion, items)
         .Methods.push_back(method);
@@ -1326,6 +1355,7 @@ namespace {
         handleNullability(function.Nullability, function.NullabilityOfRet,
                           info, info.NumAdjustedNullable-1);
       function.ResultType = copyString(info.ResultType);
+      function.RetainCountConvention = info.getRetainCountConvention();
       auto &items = getTopLevelItems(swiftVersion);
       items.Functions.push_back(function);
     }

--- a/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.apinotes
@@ -4,3 +4,39 @@ Tags:
   SwiftName: SuccessfullyRenamedA
 - Name: RenamedAgainInAPINotesB
   SwiftName: SuccessfullyRenamedB
+Functions:
+- Name: getCFOwnedToUnowned
+  RetainCountConvention: CFReturnsNotRetained
+- Name: getCFUnownedToOwned
+  RetainCountConvention: CFReturnsRetained
+- Name: getCFOwnedToNone
+  RetainCountConvention: none
+- Name: getObjCOwnedToUnowned
+  RetainCountConvention: NSReturnsNotRetained
+- Name: getObjCUnownedToOwned
+  RetainCountConvention: NSReturnsRetained
+- Name: indirectGetCFOwnedToUnowned
+  Parameters:
+  - Position: 0
+    RetainCountConvention: CFReturnsNotRetained
+- Name: indirectGetCFUnownedToOwned
+  Parameters:
+  - Position: 0
+    RetainCountConvention: CFReturnsRetained
+- Name: indirectGetCFOwnedToNone
+  Parameters:
+  - Position: 0
+    RetainCountConvention: none
+- Name: indirectGetCFNoneToOwned
+  Parameters:
+  - Position: 0
+    RetainCountConvention: CFReturnsNotRetained
+Classes:
+- Name: MethodTest
+  Methods:
+  - Selector: getOwnedToUnowned
+    MethodKind: Instance
+    RetainCountConvention: NSReturnsNotRetained
+  - Selector: getUnownedToOwned
+    MethodKind: Instance
+    RetainCountConvention: NSReturnsRetained

--- a/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.h
+++ b/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.h
@@ -5,3 +5,19 @@ struct RenamedAgainInAPINotesA {
 struct __attribute__((swift_name("bad"))) RenamedAgainInAPINotesB {
   int field;
 };
+
+void *getCFOwnedToUnowned(void) __attribute__((cf_returns_retained));
+void *getCFUnownedToOwned(void) __attribute__((cf_returns_not_retained));
+void *getCFOwnedToNone(void) __attribute__((cf_returns_retained));
+id getObjCOwnedToUnowned(void) __attribute__((ns_returns_retained));
+id getObjCUnownedToOwned(void) __attribute__((ns_returns_not_retained));
+
+int indirectGetCFOwnedToUnowned(void **out __attribute__((cf_returns_retained)));
+int indirectGetCFUnownedToOwned(void **out __attribute__((cf_returns_not_retained)));
+int indirectGetCFOwnedToNone(void **out __attribute__((cf_returns_retained)));
+int indirectGetCFNoneToOwned(void **out);
+
+@interface MethodTest
+- (id)getOwnedToUnowned __attribute__((ns_returns_retained));
+- (id)getUnownedToOwned __attribute__((ns_returns_not_retained));
+@end

--- a/test/APINotes/Inputs/roundtrip.apinotes
+++ b/test/APINotes/Inputs/roundtrip.apinotes
@@ -14,6 +14,7 @@ Classes:
     Methods:         
       - Selector:        'cellWithImage:'
         MethodKind:      Class
+        RetainCountConvention: NSReturnsNotRetained
         Availability:    available
         AvailabilityMsg: ''
         SwiftPrivate:    false
@@ -111,6 +112,16 @@ Classes:
         SwiftName:       ''
         SwiftImportAsAccessors: false
 Functions:       
+  - Name:            CFURLCopyResourcePropertiesForKeys
+    Parameters:      
+      - Position:        0
+      - Position:        1
+      - Position:        2
+        RetainCountConvention: CFReturnsRetained
+    RetainCountConvention: CFReturnsRetained
+    Availability:    available
+    AvailabilityMsg: ''
+    SwiftName:       ''
   - Name:            NSAvailableWindowDepths
     NullabilityOfRet: N
     Availability:    available
@@ -183,3 +194,4 @@ SwiftVersions:
             AvailabilityMsg: ''
             SwiftName:       ''
             SwiftImportAsAccessors: true
+...

--- a/test/APINotes/retain-count-convention.m
+++ b/test/APINotes/retain-count-convention.m
@@ -1,0 +1,20 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules  -fdisable-module-hash -fsyntax-only -F %S/Inputs/Frameworks %s
+// RUN: %clang_cc1 -ast-print %t/ModulesCache/SimpleKit.pcm | FileCheck %s
+
+#import <SimpleKit/SimpleKit.h>
+
+// CHECK: void *getCFOwnedToUnowned() __attribute__((cf_returns_not_retained));
+// CHECK: void *getCFUnownedToOwned() __attribute__((cf_returns_retained));
+// CHECK: void *getCFOwnedToNone();
+// CHECK: id getObjCOwnedToUnowned() __attribute__((ns_returns_not_retained));
+// CHECK: id getObjCUnownedToOwned() __attribute__((ns_returns_retained));
+// CHECK: int indirectGetCFOwnedToUnowned(void * _Nullable *out __attribute__((cf_returns_not_retained)));
+// CHECK: int indirectGetCFUnownedToOwned(void * _Nullable *out __attribute__((cf_returns_retained)));
+// CHECK: int indirectGetCFOwnedToNone(void * _Nullable *out);
+// CHECK: int indirectGetCFNoneToOwned(void **out __attribute__((cf_returns_not_retained)));
+
+// CHECK-LABEL: @interface MethodTest
+// CHECK: - (id)getOwnedToUnowned __attribute__((ns_returns_not_retained));
+// CHECK: - (id)getUnownedToOwned __attribute__((ns_returns_retained));
+// CHECK: @end

--- a/test/APINotes/yaml-roundtrip.c
+++ b/test/APINotes/yaml-roundtrip.c
@@ -1,10 +1,4 @@
 # RUN: %clang -cc1apinotes -yaml-to-binary -o %t.apinotesc %S/Inputs/roundtrip.apinotes
 # RUN: %clang -cc1apinotes -binary-to-yaml -o %t.apinotes %t.apinotesc
-
-# Handle the infurating '...' the YAML writer adds but the parser
-# can't read.
-
-# RUN: cp %S/Inputs/roundtrip.apinotes %t-reference.apinotes
-# RUN: echo "..." >> %t-reference.apinotes
-# RUN: diff %t-reference.apinotes %t.apinotes
+# RUN: diff %S/Inputs/roundtrip.apinotes %t.apinotes
 


### PR DESCRIPTION
This is supported on ObjC methods, functions, and parameters, which is everywhere the {ns,cf}_returns{_not,}_retained attributes are supported.

rdar://problem/34560650