### PR TITLE
Revert "Add /System/Library/PrivateFrameworks as a header search path."

### DIFF
--- a/lib/Frontend/InitHeaderSearch.cpp
+++ b/lib/Frontend/InitHeaderSearch.cpp
@@ -485,7 +485,6 @@ void InitHeaderSearch::AddDefaultIncludePaths(const LangOptions &Lang,
     if (triple.isOSDarwin()) {
       AddPath("/System/Library/Frameworks", System, true);
       AddPath("/Library/Frameworks", System, true);
-      AddPath("/System/Library/PrivateFrameworks", System, true);
     }
   }
 }


### PR DESCRIPTION
This reverts commit f7a95215a435aa8d5f64f43a8bb23ba077270755.

git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@314697 91177308-0d34-0410-b5e6-96231b3b80d8