### PR TITLE
[rename] Find ObjC class textual occurrences in string literals

### DIFF
--- a/include/clang-c/Refactor.h
+++ b/include/clang-c/Refactor.h
@@ -626,6 +626,11 @@ enum CXSymbolOccurrenceKind {
   CXSymbolOccurrence_MatchingFilename = 5,
 
   /**
+  * \brief This is an occurrence of an symbol name in a string literal.
+  */
+  CXSymbolOccurrence_MatchingStringLiteral = 6,
+
+  /**
   * \brief This is an occurrence of a symbol name that belongs to the extracted
   * declaration. Note: this occurrence can be in two replacements as we might
   * extract an out-of-line method that will be both declared and defined.
@@ -914,6 +919,7 @@ typedef struct {
    * engine requires the following cursor kinds for the following renamed
    * declaration:
    *   - ObjC methods:  CXCursor_ObjC(Instance/Class)MethodDecl
+   *   - ObjC class:    CXCursor_ObjCInterfaceDecl
    * Other declarations can use any other cursor cursor kinds.
    */
   enum CXCursorKind CursorKind;

--- a/include/clang/Tooling/Refactor/RenameIndexedFile.h
+++ b/include/clang/Tooling/Refactor/RenameIndexedFile.h
@@ -40,13 +40,18 @@ struct IndexedSymbol {
   std::vector<IndexedOccurrence> IndexedOccurrences;
   /// Whether this symbol is an Objective-C selector.
   bool IsObjCSelector;
+  /// If true, indexed file renamer will look for matching textual occurrences
+  /// in string literal tokens.
+  bool SearchForStringLiteralOccurrences;
 
   IndexedSymbol(OldSymbolName Name,
                 std::vector<IndexedOccurrence> IndexedOccurrences,
-                bool IsObjCSelector)
+                bool IsObjCSelector,
+                bool SearchForStringLiteralOccurrences = false)
       : Name(std::move(Name)),
         IndexedOccurrences(std::move(IndexedOccurrences)),
-        IsObjCSelector(IsObjCSelector) {}
+        IsObjCSelector(IsObjCSelector),
+        SearchForStringLiteralOccurrences(SearchForStringLiteralOccurrences) {}
   IndexedSymbol(IndexedSymbol &&Other) = default;
   IndexedSymbol &operator=(IndexedSymbol &&Other) = default;
 };

--- a/include/clang/Tooling/Refactor/RenamedSymbol.h
+++ b/include/clang/Tooling/Refactor/RenamedSymbol.h
@@ -79,7 +79,10 @@ public:
     MatchingDocComment,
 
     /// \brief This is an occurrence of a symbol in an inclusion directive.
-    MatchingFilename
+    MatchingFilename,
+
+    /// \brief This is a textual occurrence of a symbol in a string literal.
+    MatchingStringLiteral
   };
 
   OccurrenceKind Kind;

--- a/lib/Tooling/Refactor/RenameIndexedFile.cpp
+++ b/lib/Tooling/Refactor/RenameIndexedFile.cpp
@@ -14,6 +14,7 @@
 #include "clang/Basic/SourceManager.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendActions.h"
+#include "clang/Lex/LiteralSupport.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Tooling/Refactor/RefactoringOptions.h"
 #include "llvm/ADT/STLExtras.h"
@@ -161,6 +162,23 @@ public:
   void IndirectLex(Token &Result) override { LexFromRawLexer(Result); }
 };
 
+/// Finds matching textual occurrences in string literals.
+class StringLiteralTextualParser {
+  const OldSymbolName &Name;
+
+public:
+  unsigned SymbolIndex;
+
+  StringLiteralTextualParser(const OldSymbolName &Name, unsigned SymbolIndex)
+      : Name(Name), SymbolIndex(SymbolIndex) {
+    assert(Name.size() == 1 && "can't search for multi-piece names in strings");
+  }
+
+  /// Returns the name's location if the parses has found a matching textual
+  /// name in a string literal.
+  SourceLocation handleToken(const Token &RawTok, Preprocessor &PP);
+};
+
 } // end anonymous namespace
 
 SelectorParser::ParseState SelectorParser::stateForToken(const Token &RawTok) {
@@ -232,6 +250,19 @@ bool SelectorParser::handleToken(const Token &RawTok) {
   return true;
 }
 
+SourceLocation StringLiteralTextualParser::handleToken(const Token &RawTok,
+                                                       Preprocessor &PP) {
+  if (!tok::isStringLiteral(RawTok.getKind()))
+    return SourceLocation();
+  StringLiteralParser Literal(RawTok, PP);
+  if (Literal.hadError)
+    return SourceLocation();
+  return Literal.GetString() == Name[0]
+             ? RawTok.getLocation().getLocWithOffset(
+                   Literal.getOffsetOfStringByte(RawTok, 0))
+             : SourceLocation();
+}
+
 static void collectTextualMatchesInComment(
     ArrayRef<IndexedSymbol> Symbols, SourceLocation CommentLoc,
     StringRef Comment, llvm::SmallVectorImpl<TextualMatchOccurrence> &Result) {
@@ -301,7 +332,7 @@ static void findTextualMatchesInComment(
 }
 
 static void findMatchingTextualOccurrences(
-    const SourceManager &SM, const LangOptions &LangOpts,
+    Preprocessor &PP, const SourceManager &SM, const LangOptions &LangOpts,
     ArrayRef<IndexedSymbol> Symbols,
     llvm::function_ref<void(OldSymbolOccurrence::OccurrenceKind,
                             ArrayRef<SourceLocation> Locations,
@@ -318,9 +349,17 @@ static void findMatchingTextualOccurrences(
       SelectorParsers.push_back(
           SelectorParser(Symbol.value().Name, Symbol.index()));
   }
+  llvm::SmallVector<StringLiteralTextualParser, 1> StringParsers;
+  for (const auto &Symbol : llvm::enumerate(Symbols)) {
+    if (Symbol.value().SearchForStringLiteralOccurrences)
+      StringParsers.push_back(
+          StringLiteralTextualParser(Symbol.value().Name, Symbol.index()));
+  }
 
   Token RawTok;
   RawLex.LexFromRawLexer(RawTok);
+  bool ScanNonCommentTokens =
+      !SelectorParsers.empty() || !StringParsers.empty();
   while (RawTok.isNot(tok::eof)) {
     if (RawTok.is(tok::comment)) {
       SourceRange Range(RawTok.getLocation(), RawTok.getEndLoc());
@@ -333,11 +372,17 @@ static void findMatchingTextualOccurrences(
                                     Range, MatchHandler);
         CommentMatches.clear();
       }
-    } else if (!SelectorParsers.empty()) {
+    } else if (ScanNonCommentTokens) {
       for (auto &Parser : SelectorParsers) {
         if (Parser.handleToken(RawTok))
           MatchHandler(OldSymbolOccurrence::MatchingSelector,
                        Parser.SelectorLocations, Parser.SymbolIndex);
+      }
+      for (auto &Parser : StringParsers) {
+        SourceLocation Loc = Parser.handleToken(RawTok, PP);
+        if (Loc.isValid())
+          MatchHandler(OldSymbolOccurrence::MatchingStringLiteral, Loc,
+                       Parser.SymbolIndex);
       }
     }
     RawLex.LexFromRawLexer(RawTok);
@@ -432,7 +477,7 @@ void IndexedFileOccurrenceProducer::ExecuteAction() {
   if (Options && Options->get(option::AvoidTextualMatches()))
     return;
   findMatchingTextualOccurrences(
-      SM, LangOpts, Symbols,
+      PP, SM, LangOpts, Symbols,
       [&](OldSymbolOccurrence::OccurrenceKind Kind,
           ArrayRef<SourceLocation> Locations, unsigned SymbolIndex) {
         OldSymbolOccurrence Result(Kind, /*IsMacroExpansion=*/false,

--- a/test/Refactor/Rename/IndexedObjCClassStringLiteral.mm
+++ b/test/Refactor/Rename/IndexedObjCClassStringLiteral.mm
@@ -1,0 +1,21 @@
+@interface Test
+
+@end
+
+void foo() {
+  "Test"; // CHECK: string-literal [[@LINE]]:4 -> [[@LINE]]:8
+  @"Test"; // CHECK: string-literal [[@LINE]]:5 -> [[@LINE]]:9
+  u8"Test";  // CHECK: string-literal [[@LINE]]:6 -> [[@LINE]]:10
+  // CHECK-NOT: string-literal
+  "Test.h";
+  " Test ";
+  "test";
+  "TEST";
+}
+
+// RUN: clang-refactor-test rename-indexed-file -name=Test -new-name=foo -indexed-file=%s -indexed-at=1:12 -indexed-symbol-kind=objc-class %s -std=c++11 | FileCheck %s
+// It should be possible to find a string-literal in a file without any indexed occurrences:
+// RUN: clang-refactor-test rename-indexed-file -name=Test -new-name=foo -indexed-file=%s -indexed-symbol-kind=objc-class %s -std=c++11 | FileCheck %s
+
+// RUN: clang-refactor-test rename-indexed-file -name=Test -new-name=foo -indexed-file=%s -indexed-at=1:12 %s -std=c++11 | FileCheck --check-prefix=NOTCLASS %s
+// NOTCLASS-NOT: string-literal

--- a/test/Refactor/Rename/IndexedObjCMethod.m
+++ b/test/Refactor/Rename/IndexedObjCMethod.m
@@ -96,7 +96,7 @@ selector(performAction:with)
 // CHECK3-NOT: comment
 // CHECK3-NOT: documentation
 // CHECK3-NOT: selector
-
+// CHECK3-NOT: string-literal
 // It should be possible to find a selector in a file without any indexed occurrences:
 
 // CHECK4: selector [[@LINE+1]]:11

--- a/tools/clang-refactor-test/ClangRefactorTest.cpp
+++ b/tools/clang-refactor-test/ClangRefactorTest.cpp
@@ -255,6 +255,8 @@ static const char *renameOccurrenceKindString(CXSymbolOccurrenceKind Kind,
     return "documentation";
   case CXSymbolOccurrence_MatchingFilename:
     return "filename";
+  case CXSymbolOccurrence_MatchingStringLiteral:
+    return "string-literal";
   case CXSymbolOccurrence_ExtractedDeclaration:
     return "extracted-decl";
   case CXSymbolOccurrence_ExtractedDeclaration_Reference:
@@ -397,6 +399,7 @@ renameIndexedOccurrenceKindStringToKind(StringRef Str, CXCursorKind Default) {
       .Case("objc-cm", CXCursor_ObjCClassMethodDecl)
       .Case("objc-message", CXCursor_ObjCMessageExpr)
       .Case("include", CXCursor_InclusionDirective)
+      .Case("objc-class", CXCursor_ObjCInterfaceDecl)
       .Default(Default);
 }
 

--- a/tools/libclang/CRefactor.cpp
+++ b/tools/libclang/CRefactor.cpp
@@ -79,6 +79,8 @@ translateOccurrenceKind(rename::OldSymbolOccurrence::OccurrenceKind Kind) {
     return CXSymbolOccurrence_MatchingDocCommentString;
   case rename::OldSymbolOccurrence::MatchingFilename:
     return CXSymbolOccurrence_MatchingFilename;
+  case rename::OldSymbolOccurrence::MatchingStringLiteral:
+    return CXSymbolOccurrence_MatchingStringLiteral;
   }
 }
 
@@ -671,9 +673,11 @@ CXErrorCode performIndexedSymbolSearch(
       IndexedOccurrences.push_back(Result);
     }
 
-    IndexedSymbols.emplace_back(OldSymbolName(Symbol.Name, IsObjCSelector),
-                                IndexedOccurrences,
-                                /*IsObjCSelector=*/IsObjCSelector);
+    IndexedSymbols.emplace_back(
+        OldSymbolName(Symbol.Name, IsObjCSelector), IndexedOccurrences,
+        /*IsObjCSelector=*/IsObjCSelector,
+        /*SearchForStringLiteralOccurrences=*/
+        Symbol.CursorKind == CXCursor_ObjCInterfaceDecl);
   }
 
   class ToolRunner final : public FrontendActionFactory,


### PR DESCRIPTION
Occurrences match only when the string's text is exactly the same as class name.

rdar://33861206