### PR TITLE
Unblock SwiftCC usage on Windows

### DIFF
--- a/lib/AST/MicrosoftMangle.cpp
+++ b/lib/AST/MicrosoftMangle.cpp
@@ -2131,9 +2131,12 @@ void MicrosoftCXXNameMangler::mangleCallingConvention(CallingConv CC) {
 
   switch (CC) {
     default:
-      llvm_unreachable("Unsupported CC for mangling");
+      llvm::errs() << "Unsupported CC for mangling: " << CC << ".\n";
     case CC_Win64:
     case CC_X86_64SysV:
+    // FIXME: SwiftCC should have its own mangling specifier.
+    // For now, don't do anything special for SwiftCC mangling.
+    case CC_Swift:
     case CC_C: Out << 'A'; break;
     case CC_X86Pascal: Out << 'C'; break;
     case CC_X86ThisCall: Out << 'E'; break;


### PR DESCRIPTION
We don't have a sensible way to mangle functions using the Swift calling convention on Windows currently. For now, as per [discussions on swift-dev](https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20171204/006123.html), don't do anything special and mangle it like the C calling convention.

Also in this patch, address [feedback](https://reviews.llvm.org/D31372) on usage of `llvm_unreachable`. 