### PR TITLE
[tools] Add private to link_target_libraries.

### DIFF
--- a/tools/c-index-test/CMakeLists.txt
+++ b/tools/c-index-test/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(APPLE)
   check_include_files("CoreServices/CoreServices.h" HAVE_CORESERVICES_H)
   if(HAVE_CORESERVICES_H)
-    target_link_libraries(c-index-test "-framework CoreServices")
+    target_link_libraries(c-index-test PRIVATE "-framework CoreServices")
   endif()
 endif()
 

--- a/tools/clang-refactor-test/CMakeLists.txt
+++ b/tools/clang-refactor-test/CMakeLists.txt
@@ -8,10 +8,12 @@ add_clang_executable(clang-refactor-test
 
 if (LLVM_BUILD_STATIC)
   target_link_libraries(clang-refactor-test
+    PRIVATE
     libclang_static
   )
 else()
   target_link_libraries(clang-refactor-test
+    PRIVATE
     libclang
     clangBasic
     clangFrontend


### PR DESCRIPTION
This unbreaks swift-lldb testing.