### PR TITLE
[IndexingAction] Fix build failure due to a mismerge.

### DIFF
--- a/lib/Index/IndexingAction.cpp
+++ b/lib/Index/IndexingAction.cpp
@@ -451,7 +451,8 @@ protected:
     DepCollector.setSysrootPath(IndexCtx.getSysrootPath());
     DepCollector.attachToPreprocessor(PP);
 
-    return llvm::make_unique<IndexASTConsumer>(IndexCtx);
+    return llvm::make_unique<IndexASTConsumer>(CI.getPreprocessorPtr(),
+                                               IndexCtx);
   }
 
   void finish(CompilerInstance &CI);


### PR DESCRIPTION
I need this to unbreak swift-lldb.