### PR TITLE
Fix the DirectoryWatcher link failure in shared libs build of clang

### DIFF
--- a/lib/DirectoryWatcher/CMakeLists.txt
+++ b/lib/DirectoryWatcher/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(CheckIncludeFiles)
+
 set(LLVM_LINK_COMPONENTS support)
 
 add_clang_library(clangDirectoryWatcher
@@ -6,3 +8,14 @@ add_clang_library(clangDirectoryWatcher
   LINK_LIBS
   clangBasic
   )
+
+if(BUILD_SHARED_LIBS)
+  if(APPLE)
+    check_include_files("CoreServices/CoreServices.h" HAVE_CORESERVICES_H)
+    if(HAVE_CORESERVICES_H)
+      set(DIRECTORY_WATCHER_FLAGS "${DIRECTORY_WATCHER_FLAGS} -framework CoreServices")
+    endif()
+    set_property(TARGET clangDirectoryWatcher APPEND_STRING PROPERTY
+                 LINK_FLAGS ${DIRECTORY_WATCHER_FLAGS})
+  endif()
+endif()


### PR DESCRIPTION
rdar://33603328