### PR TITLE
Make indexstore.h importable by Swift.

### DIFF
--- a/include/indexstore/indexstore.h
+++ b/include/indexstore/indexstore.h
@@ -14,9 +14,10 @@
 #ifndef LLVM_CLANG_C_INDEXSTORE_INDEXSTORE_H
 #define LLVM_CLANG_C_INDEXSTORE_INDEXSTORE_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
-#include <ctime>
+#include <time.h>
 
 /**
  * \brief The version constants for the Index Store C API.
@@ -126,7 +127,7 @@ indexstore_unit_event_get_kind(indexstore_unit_event_t);
 INDEXSTORE_PUBLIC indexstore_string_ref_t
 indexstore_unit_event_get_unit_name(indexstore_unit_event_t);
 
-INDEXSTORE_PUBLIC timespec
+INDEXSTORE_PUBLIC struct timespec
 indexstore_unit_event_get_modification_time(indexstore_unit_event_t);
 
 #if INDEXSTORE_HAS_BLOCKS


### PR DESCRIPTION
This change removes some C++-specific things that prevented Swift from being able to import this header (when provided with a module map).