### PR TITLE
Tooling: silence -Wreturn-type warning

### DIFF
--- a/lib/Tooling/Refactor/RefactoringActions.cpp
+++ b/lib/Tooling/Refactor/RefactoringActions.cpp
@@ -24,6 +24,7 @@ StringRef getRefactoringActionTypeName(RefactoringActionType Action) {
     return Spelling;
 #include "clang/Tooling/Refactor/RefactoringActions.def"
   }
+  llvm_unreachable("unexpected RefactoringActionType value");
 }
 
 } // end namespace tooling


### PR DESCRIPTION
The switch should be covered.  However, older versions of gcc and clang as well
as MSVC do not handle the covered switch and emit a warning.  Silence the
warning by adding an unreachable.  NFC.