### PR TITLE
clang-refactor-test: silence -Wreturn-type warning

### DIFF
--- a/tools/clang-refactor-test/ClangRefactorTest.cpp
+++ b/tools/clang-refactor-test/ClangRefactorTest.cpp
@@ -262,6 +262,7 @@ static const char *renameOccurrenceKindString(CXSymbolOccurrenceKind Kind,
   case CXSymbolOccurrence_ExtractedDeclaration_Reference:
     return "extracted-decl-ref";
   }
+  llvm_unreachable("unexpected CXSymbolOccurrenceKind value");
 }
 
 static int apply(ArrayRef<CXRefactoringReplacement> Replacements,


### PR DESCRIPTION
The switch should be covered. However, older versions of gcc and clang as well
as MSVC do not handle the covered switch and emit a warning. Silence the
warning by adding an unreachable. NFC.