### PR TITLE
Tooling: fix -fpermissive warning from gcc

### DIFF
--- a/lib/Tooling/Refactor/RefactoringOptions.cpp
+++ b/lib/Tooling/Refactor/RefactoringOptions.cpp
@@ -26,6 +26,8 @@ void RefactoringOptionSet::print(llvm::raw_ostream &OS) const {
   }
 }
 
+namespace llvm {
+namespace yaml {
 template <> struct CustomMappingTraits<RefactoringOptionSet> {
   static void inputOne(IO &YamlIn, StringRef Key,
                        RefactoringOptionSet &Result) {
@@ -44,6 +46,8 @@ template <> struct CustomMappingTraits<RefactoringOptionSet> {
     llvm_unreachable("Output is done without mapping traits");
   }
 };
+}
+}
 
 llvm::Expected<RefactoringOptionSet>
 RefactoringOptionSet::parse(StringRef Source) {


### PR DESCRIPTION
Explicitly wrap the template specialization into the namespace where it
is declared (in LLVM).  This fixes a `-fpermissive` error emitted by GCC
when building clang for swift.  NFC.