### PR TITLE
clang-c: indicate correct linkage

### DIFF
--- a/include/clang-c/Refactor.h
+++ b/include/clang-c/Refactor.h
@@ -1132,6 +1132,7 @@ typedef struct {
  * \brief Return the set of symbol occurrences that are associated with the
  * given \p Replacement.
  */
+CINDEX_LINKAGE
 CXRefactoringReplacementAssociatedSymbolOccurrences
 clang_RefactoringReplacement_getAssociatedSymbolOccurrences(
     CXRefactoringReplacement Replacement);


### PR DESCRIPTION
The `clang_RefactoringReplacement_getAssociatedSymbolOccurrences`
declaration was missing the linkage annotation resulting in a build
failure on Windows.  Correct the linkage annotations.