### PR TITLE
libclang: silence -Wreturn-type warning

### DIFF
--- a/tools/libclang/CRefactor.cpp
+++ b/tools/libclang/CRefactor.cpp
@@ -52,6 +52,7 @@ translateRefactoringActionType(CXRefactoringActionType Action) {
     return RefactoringActionType::Name;
 #include "clang/Tooling/Refactor/RefactoringActions.def"
   }
+  llvm_unreachable("unknown CXRefactoringActionType value");
 }
 
 static CXRefactoringActionType
@@ -62,6 +63,7 @@ translateRefactoringActionType(RefactoringActionType Action) {
     return CXRefactor_##Name;
 #include "clang/Tooling/Refactor/RefactoringActions.def"
   }
+  llvm_unreachable("unknown RefactoringActionType value");
 }
 
 static CXSymbolOccurrenceKind
@@ -82,6 +84,7 @@ translateOccurrenceKind(rename::OldSymbolOccurrence::OccurrenceKind Kind) {
   case rename::OldSymbolOccurrence::MatchingStringLiteral:
     return CXSymbolOccurrence_MatchingStringLiteral;
   }
+  llvm_unreachable("unknown OccurrenceKind value");
 }
 
 namespace {


### PR DESCRIPTION
The switch should be covered. However, older versions of gcc and clang
as well as MSVC do not handle the covered switch and emit a warning.
Silence the warning by adding an unreachable. NFC.