### PR TITLE
Tooling: use /bigobj when building a file

### DIFF
--- a/lib/Tooling/Refactor/CMakeLists.txt
+++ b/lib/Tooling/Refactor/CMakeLists.txt
@@ -43,3 +43,7 @@ add_clang_library(clangToolingRefactor
   clangToolingCore
   clangRewrite
   )
+
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  set_source_files_properties(Extract.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+endif()


### PR DESCRIPTION
This file has enough symbols that it extends beyond the PE/COFF
specification.  Use `/bigobj` to enable builds on Windows.