### PR TITLE
[WIP] [APINotes] Add a 'swift_nonbridged' attribute for typedefs

### DIFF
--- a/include/clang/APINotes/Types.h
+++ b/include/clang/APINotes/Types.h
@@ -767,6 +767,7 @@ enum class SwiftWrapperKind {
 class TypedefInfo : public CommonTypeInfo {
 public:
   Optional<SwiftWrapperKind> SwiftWrapper;
+  Optional<bool> SwiftNonbridged;
 
   TypedefInfo() : CommonTypeInfo() { }
 
@@ -774,12 +775,15 @@ public:
     lhs |= static_cast<const CommonTypeInfo &>(rhs);
     if (!lhs.SwiftWrapper.hasValue() && rhs.SwiftWrapper.hasValue())
       lhs.SwiftWrapper = rhs.SwiftWrapper;
+    if (!lhs.SwiftNonbridged.hasValue() && rhs.SwiftNonbridged.hasValue())
+      lhs.SwiftNonbridged = rhs.SwiftNonbridged;
     return lhs;
   }
 
   friend bool operator==(const TypedefInfo &lhs, const TypedefInfo &rhs) {
     return static_cast<const CommonTypeInfo &>(lhs) == rhs &&
-           lhs.SwiftWrapper == rhs.SwiftWrapper;
+           lhs.SwiftWrapper == rhs.SwiftWrapper &&
+           lhs.SwiftNonbridged == rhs.SwiftNonbridged;
   }
 };
 

--- a/include/clang/Basic/Attr.td
+++ b/include/clang/Basic/Attr.td
@@ -1708,6 +1708,12 @@ def SwiftNewtype : InheritableAttr {
   let Documentation = [SwiftNewtypeDocs];
 }
 
+def SwiftNonbridged : InheritableAttr {
+  let Spellings = [GNU<"swift_nonbridged">];
+  let Subjects = SubjectList<[TypedefName], ErrorDiag, "ExpectedType">;
+  let Documentation = [Undocumented];
+}
+
 def SwiftPrivate : InheritableAttr {
   let Spellings = [GCC<"swift_private">];
   let Documentation = [Undocumented];

--- a/lib/APINotes/APINotesFormat.h
+++ b/lib/APINotes/APINotesFormat.h
@@ -36,7 +36,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// API notes file minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t VERSION_MINOR = 24;  // EnumExtensibility+FlagEnum
+const uint16_t VERSION_MINOR = 25;  // swift_nonbridged
 
 using IdentifierID = PointerEmbeddedInt<unsigned, 31>;
 using IdentifierIDField = BCVBR<16>;

--- a/lib/APINotes/APINotesReader.cpp
+++ b/lib/APINotes/APINotesReader.cpp
@@ -1,4 +1,4 @@
-//===--- APINotesReader.cpp - Side Car Reader --------------------*- C++ -*-===//
+//===--- APINotesReader.cpp - Side Car Reader -------------------*- C++ -*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -525,9 +525,12 @@ namespace {
       TypedefInfo info;
 
       uint8_t payload = *data++;
-      if (payload > 0) {
+      if ((payload & 0x3) > 0) {
         info.SwiftWrapper = static_cast<SwiftWrapperKind>((payload & 0x3) - 1);
       }
+      payload >>= 3;
+      if (payload & 0x1)
+        info.SwiftNonbridged = (bool)(payload & 0x2);
 
       readCommonTypeInfo(data, info);
       return info;

--- a/lib/APINotes/APINotesWriter.cpp
+++ b/lib/APINotes/APINotesWriter.cpp
@@ -1,4 +1,4 @@
-//===--- APINotesWriter.cpp - API Notes Writer --------------------*- C++ -*-===//
+//===--- APINotesWriter.cpp - API Notes Writer ------------------*- C++ -*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -1141,6 +1141,13 @@ namespace {
       endian::Writer<little> writer(out);
 
       uint8_t payload = 0;
+
+      if (Optional<bool> value = info.SwiftNonbridged) {
+        payload |= 1 << 0;
+        payload |= value.getValue() << 1;
+      }
+
+      payload <<= 3;
       if (auto swiftWrapper = info.SwiftWrapper) {
         payload |= static_cast<uint8_t>(*swiftWrapper) + 1;
       }

--- a/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -287,6 +287,7 @@ namespace {
     AvailabilityItem Availability;
     StringRef SwiftName;
     Optional<bool> SwiftPrivate;
+    Optional<bool> SwiftNonbridged;
     Optional<StringRef> SwiftBridge;
     Optional<StringRef> NSErrorDomain;
     Optional<api_notes::SwiftWrapperKind> SwiftWrapper;
@@ -582,8 +583,9 @@ namespace llvm {
         io.mapOptional("SwiftPrivate",          t.SwiftPrivate);
         io.mapOptional("SwiftName",             t.SwiftName);
         io.mapOptional("SwiftBridge",           t.SwiftBridge);
+        io.mapOptional("SwiftNonbridged",       t.SwiftNonbridged);
         io.mapOptional("NSErrorDomain",         t.NSErrorDomain);
-        io.mapOptional("SwiftWrapper",         t.SwiftWrapper);
+        io.mapOptional("SwiftWrapper",          t.SwiftWrapper);
       }
     };
 
@@ -1049,6 +1051,7 @@ namespace {
         if (convertCommonType(t, typedefInfo, t.Name))
           continue;
         typedefInfo.SwiftWrapper = t.SwiftWrapper;
+        typedefInfo.SwiftNonbridged = t.SwiftNonbridged;
 
         Writer->addTypedef(t.Name, typedefInfo, swiftVersion);
       }
@@ -1405,6 +1408,7 @@ namespace {
       td.Name = name;
       handleCommonType(td, info);
       td.SwiftWrapper = info.SwiftWrapper;
+      td.SwiftNonbridged = info.SwiftNonbridged;
       auto &items = getTopLevelItems(swiftVersion);
       items.Typedefs.push_back(td);
     }

--- a/lib/Sema/SemaAPINotes.cpp
+++ b/lib/Sema/SemaAPINotes.cpp
@@ -669,6 +669,13 @@ static void ProcessAPINotes(Sema &S, TypedefNameDecl *D,
     });
   }
 
+  if (Optional<bool> nonbridged = info.SwiftNonbridged) {
+    handleAPINotedAttribute<SwiftNonbridgedAttr>(S, D, nonbridged.getValue(),
+                                                 metadata, [&] {
+      return SwiftNonbridgedAttr::CreateImplicit(S.Context);
+    });
+  }
+
   // Handle common type information.
   ProcessAPINotes(S, D, static_cast<const api_notes::CommonTypeInfo &>(info),
                   metadata);

--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -7048,6 +7048,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case AttributeList::AT_SwiftNewtype:
     handleSwiftNewtypeAttr(S, D, Attr);
     break;
+  case AttributeList::AT_SwiftNonbridged:
+    handleSimpleAttribute<SwiftNonbridgedAttr>(S, D, Attr);
+    break;
   // XRay attributes.
   case AttributeList::AT_XRayInstrument:
     handleSimpleAttribute<XRayInstrumentAttr>(S, D, Attr);

--- a/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.apinotes
@@ -125,6 +125,8 @@ SwiftVersions:
         SwiftName: MultiVersionedTypedef45Header_5
       - Name: MultiVersionedTypedef45Notes
         SwiftName: MultiVersionedTypedef45Notes_5
+      - Name: UnbridgedNSString
+        SwiftNonbridged: false
   - Version: 4 # Versions are deliberately ordered as "3, 5, 4" to catch bugs.
     Classes:
       - Name: Swift4RenamedDUMP

--- a/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.h
+++ b/test/APINotes/Inputs/Frameworks/VersionedKit.framework/Headers/VersionedKit.h
@@ -49,6 +49,8 @@ __attribute__((swift_name("Swift4Name")))
 @interface Swift4RenamedDUMP
 @end
 
+typedef NSString *UnbridgedNSString __attribute__((swift_nonbridged));
+
 #endif
 
 

--- a/test/APINotes/Inputs/roundtrip.apinotes
+++ b/test/APINotes/Inputs/roundtrip.apinotes
@@ -164,6 +164,7 @@ Typedefs:
     SwiftPrivate:    false
     SwiftName:       Typedef
     SwiftBridge:     ''
+    SwiftNonbridged: false
     SwiftWrapper:    struct
 SwiftVersions:   
   - Version:         3.0

--- a/test/APINotes/versioned.m
+++ b/test/APINotes/versioned.m
@@ -95,6 +95,9 @@
 // CHECK-VERSIONED-NOT: __attribute__((swift_objc_members)
 // CHECK-VERSIONED: @interface TestProperties
 
+// CHECK-UNVERSIONED: typedef NSString *UnbridgedNSString __attribute__((swift_nonbridged));
+// CHECK-VERSIONED: typedef NSString *UnbridgedNSString;
+
 // CHECK-UNVERSIONED-LABEL: enum FlagEnum {
 // CHECK-UNVERSIONED-NEXT:     FlagEnumA = 1,
 // CHECK-UNVERSIONED-NEXT:     FlagEnumB = 2


### PR DESCRIPTION
Some APIs really need reference semantics even for a type that's normally bridged to a Swift value type, such as the NSString view onto NSTextStorage's backing in AppKit. Up until now people have had to work around this with hacks, usually wrapper functions that return an "NSObject" that then can be downcast back to NSString. This new Clang attribute avoids that.

rdar://problem/28480421

* * *

This PR is targeting the `stable` branch, and should not be merged until this change is also in `upstream-with-swift`.