### PR TITLE
Include missing header to fix the build after Clang r327573

### DIFF
--- a/tools/libclang/CRefactor.cpp
+++ b/tools/libclang/CRefactor.cpp
@@ -26,6 +26,7 @@
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/Utils.h"
 #include "clang/Index/USRGeneration.h"
+#include "clang/Tooling/CompilationDatabase.h"
 #include "clang/Tooling/Refactor/IndexerQuery.h"
 #include "clang/Tooling/Refactor/RefactoringActionFinder.h"
 #include "clang/Tooling/Refactor/RefactoringActions.h"


### PR DESCRIPTION
The "clang/Tooling/CompilationDatabase.h" header is no longer included
by "clang/Tooling/Tooling.h".