### PR TITLE
CodeGenCXX: support PreserveMostCC in MS ABI

### DIFF
--- a/lib/AST/MicrosoftMangle.cpp
+++ b/lib/AST/MicrosoftMangle.cpp
@@ -2140,6 +2140,7 @@ void MicrosoftCXXNameMangler::mangleCallingConvention(CallingConv CC) {
     case CC_X86FastCall: Out << 'I'; break;
     case CC_X86VectorCall: Out << 'Q'; break;
     case CC_Swift: Out << 'S'; break;
+    case CC_PreserveMost: Out << 'U'; break;
     case CC_X86RegCall: Out << 'w'; break;
   }
 }

--- a/lib/Basic/Targets/X86.h
+++ b/lib/Basic/Targets/X86.h
@@ -269,6 +269,7 @@ public:
     case CC_X86VectorCall:
     case CC_X86RegCall:
     case CC_C:
+    case CC_PreserveMost:
     case CC_Swift:
     case CC_X86Pascal:
     case CC_IntelOclBicc:

--- a/test/CodeGenCXX/msabi-swiftcall-cc.cpp
+++ b/test/CodeGenCXX/msabi-swiftcall-cc.cpp
@@ -1,28 +1,67 @@
 // RUN: %clang_cc1 -triple i686-unknown-windows-msvc -fdeclspec -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-unknown-windows-msvc -fdeclspec -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-64
 
 void __attribute__((__swiftcall__)) f() {}
 // CHECK-DAG: @"\01?f@@YSXXZ"
+// CHECK-64-DAG: @"\01?f@@YSXXZ"
 
 void (__attribute__((__swiftcall__)) *p)();
 // CHECK-DAG: @"\01?p@@3P6SXXZA"
+// CHECK-64-DAG: @"\01?p@@3P6SXXZEA
 
 namespace {
 void __attribute__((__swiftcall__)) __attribute__((__used__)) f() { }
-// CHECK-DAG: "\01?f@?A@@YSXXZ"
 }
+// CHECK-DAG: @"\01?f@?A@@YSXXZ"
+// CHECK-64-DAG: @"\01?f@?A@@YSXXZ"
 
 namespace n {
 void __attribute__((__swiftcall__)) f() {}
-// CHECK-DAG: "\01?f@n@@YSXXZ"
 }
+// CHECK-DAG: @"\01?f@n@@YSXXZ"
+// CHECK-64-DAG: @"\01?f@n@@YSXXZ"
 
 struct __declspec(dllexport) S {
   S(const S &) = delete;
   S & operator=(const S &) = delete;
   void __attribute__((__swiftcall__)) m() { }
-  // CHECK-DAG: "\01?m@S@@QASXXZ"
 };
+// CHECK-DAG: @"\01?m@S@@QASXXZ"
+// CHECK-64-DAG: @"\01?m@S@@QEASXXZ"
 
 void f(void (__attribute__((__swiftcall__))())) {}
-// CHECK-DAG: "\01?f@@YAXP6SXXZ@Z"
+// CHECK-DAG: @"\01?f@@YAXP6SXXZ@Z"
+// CHECK-64-DAG: @"\01?f@@YAXP6SXXZ@Z"
+
+void __attribute__((__preserve_most__)) g() {}
+// CHECK-DAG: @"\01?g@@YUXXZ"
+// CHECK-64-DAG: @"\01?g@@YUXXZ"
+
+void (__attribute__((__preserve_most__)) *q)();
+// CHECK-DAG: @"\01?q@@3P6UXXZA"
+// CHECK-64-DAG: @"\01?q@@3P6UXXZEA"
+
+namespace {
+void __attribute__((__preserve_most__)) __attribute__((__used__)) g() {}
+}
+// CHECK-DAG: @"\01?g@?A@@YUXXZ"
+// CHECK-64-DAG: @"\01?g@?A@@YUXXZ"
+
+namespace n {
+void __attribute__((__preserve_most__)) g() {}
+}
+// CHECK-DAG: @"\01?g@n@@YUXXZ"
+// CHECK-64-DAG: @"\01?g@n@@YUXXZ"
+
+struct __declspec(dllexport) T {
+  T(const T &) = delete;
+  T & operator=(const T &) = delete;
+  void __attribute__((__preserve_most__)) m() {}
+};
+// CHECK-DAG: @"\01?m@T@@QAUXXZ"
+// CHECK-64-DAG: @"\01?m@T@@QEAUXXZ"
+
+void g(void (__attribute__((__preserve_most__))())) {}
+// CHECK-DAG: @"\01?g@@YAXP6UXXZ@Z"
+// CHECK-64-DAG: @"\01?g@@YAXP6UXXZ@Z"
 


### PR DESCRIPTION
Microsoft has reserved 'U' for the PreserveMostCC which is used in the
swift runtime.  Add support for this.  This allows the swift runtime to
be built for Windows again.

git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@329025 91177308-0d34-0410-b5e6-96231b3b80d8