### PR TITLE
Lex: make `clang::Preprocessor::macros` work on MSVC

### DIFF
--- a/include/clang/Lex/Preprocessor.h
+++ b/include/clang/Lex/Preprocessor.h
@@ -1041,12 +1041,14 @@ public:
 
   macro_iterator macro_begin(bool IncludeExternalMacros = true) const;
   macro_iterator macro_end(bool IncludeExternalMacros = true) const;
-  llvm::iterator_range<macro_iterator>
 
+  llvm::iterator_range<macro_iterator>
   macros(bool IncludeExternalMacros = true) const {
-    return llvm::make_range(macro_begin(IncludeExternalMacros),
-                            macro_end(IncludeExternalMacros));
+    macro_iterator begin = macro_begin(IncludeExternalMacros);
+    macro_iterator end = macro_end(IncludeExternalMacros);
+    return llvm::make_range(begin, end);
   }
+
   /// \}
 
   /// \brief Return the name of the macro defined before \p Loc that has


### PR DESCRIPTION
The order of argument construction is reversed on MS ABI on Windows.
When `macros` was invoked, the `end` call is made prior to `begin`.  In
such a case, the DenseMap (`ModuleMap`) is populated after the `end`
iterator is constructed.  This reversal results in the invalidation of
the end iterator, resulting in a failure at runtime (assertion failure
in `DenseMap<T>::operator!=` that "handles are not in sync!").  Ensure
that the end iterator is constructed after the begin iterator.  This
fixes the use of `macros(bool)`, which symptomized as an assertion
failure in the swift compiler in the clang importer.

git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@329866 91177308-0d34-0410-b5e6-96231b3b80d8