### PR TITLE
Tweak search path for API notes for private top-level modules

### DIFF
--- a/include/clang/Basic/Module.h
+++ b/include/clang/Basic/Module.h
@@ -233,9 +233,6 @@ public:
   /// \brief Whether this is an inferred submodule (module * { ... }).
   unsigned IsInferred : 1;
 
-  /// \brief Whether this is a module who has its swift_names inferred.
-  unsigned IsSwiftInferImportAsMember : 1;
-
   /// \brief Whether we should infer submodules for this module based on 
   /// the headers.
   ///
@@ -264,6 +261,9 @@ public:
   /// \brief Whether this module came from a "private" module map, found next
   /// to a regular (public) module map.
   unsigned ModuleMapIsPrivate : 1;
+
+  /// \brief Whether this is a module who has its swift_names inferred.
+  unsigned IsSwiftInferImportAsMember : 1;
 
   /// \brief Describes the visibility of the various names within a
   /// particular module.

--- a/lib/Basic/Module.cpp
+++ b/lib/Basic/Module.cpp
@@ -38,14 +38,19 @@ using namespace clang;
 Module::Module(StringRef Name, SourceLocation DefinitionLoc, Module *Parent,
                bool IsFramework, bool IsExplicit, unsigned VisibilityID)
     : Name(Name), DefinitionLoc(DefinitionLoc), Parent(Parent), Directory(),
-      Umbrella(), ASTFile(nullptr), VisibilityID(VisibilityID),
-      IsMissingRequirement(false), HasIncompatibleModuleFile(false),
-      IsAvailable(true), IsFromModuleFile(false), IsFramework(IsFramework),
-      IsExplicit(IsExplicit), IsSystem(false), IsExternC(false),
-      IsInferred(false), IsSwiftInferImportAsMember(false),
+      Umbrella(), ASTFile(nullptr),
+      VisibilityID(VisibilityID), IsMissingRequirement(false),
+      HasIncompatibleModuleFile(false), IsAvailable(true),
+      IsFromModuleFile(false), IsFramework(IsFramework), IsExplicit(IsExplicit),
+      IsSystem(false), IsExternC(false), IsInferred(false),
       InferSubmodules(false), InferExplicitSubmodules(false),
       InferExportWildcard(false), ConfigMacrosExhaustive(false),
       NoUndeclaredIncludes(false), ModuleMapIsPrivate(false),
+
+      // SWIFT-SPECIFIC FIELDS HERE. Handling them separately helps avoid merge
+      // conflicts.
+      IsSwiftInferImportAsMember(false),
+
       NameVisibility(Hidden) {
   if (Parent) {
     if (!Parent->isAvailable())

--- a/lib/Serialization/ASTWriter.cpp
+++ b/lib/Serialization/ASTWriter.cpp
@@ -2801,11 +2801,15 @@ void ASTWriter::WriteSubmodules(Module *WritingModule) {
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // ID
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // Parent
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 2)); // Kind
+
+  // SWIFT-SPECIFIC FIELDS HERE. Handling them separately helps avoid merge
+  // conflicts.
+  Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // IsSwiftInferIAM...
+
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // IsFramework
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // IsExplicit
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // IsSystem
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // IsExternC
-  Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // IsSwiftInferIAM...
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // InferSubmodules...
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // InferExplicit...
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // InferExportWild...
@@ -2908,11 +2912,16 @@ void ASTWriter::WriteSubmodules(Module *WritingModule) {
                                          ID,
                                          ParentID,
                                          (RecordData::value_type)Mod->Kind,
+
+                                         // SWIFT-SPECIFIC FIELDS HERE.
+                                         // Handling them separately helps
+                                         // avoid merge conflicts.
+                                         Mod->IsSwiftInferImportAsMember,
+
                                          Mod->IsFramework,
                                          Mod->IsExplicit,
                                          Mod->IsSystem,
                                          Mod->IsExternC,
-                                         Mod->IsSwiftInferImportAsMember,
                                          Mod->InferSubmodules,
                                          Mod->InferExplicitSubmodules,
                                          Mod->InferExportWildcard,

--- a/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/Headers/TopLevelPrivateKit.h
+++ b/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/Headers/TopLevelPrivateKit.h
@@ -1,0 +1,1 @@
+extern int TopLevelPrivateKit_Public;

--- a/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/Headers/TopLevelPrivateKit_Private.apinotes
+++ b/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/Headers/TopLevelPrivateKit_Private.apinotes
@@ -1,0 +1,1 @@
+garbage here because this file shouldn't get read

--- a/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/Modules/module.modulemap
+++ b/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module TopLevelPrivateKit {
+  umbrella header "TopLevelPrivateKit.h"
+  export *
+  module * { export * }
+}

--- a/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/Modules/module.private.modulemap
+++ b/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/Modules/module.private.modulemap
@@ -1,0 +1,5 @@
+framework module TopLevelPrivateKit_Private {
+  umbrella header "TopLevelPrivateKit_Private.h"
+  export *
+  module * { export * }
+}

--- a/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/PrivateHeaders/TopLevelPrivateKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/PrivateHeaders/TopLevelPrivateKit.apinotes
@@ -1,0 +1,1 @@
+garbage here because this file shouldn't get read

--- a/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/PrivateHeaders/TopLevelPrivateKit_Private.apinotes
+++ b/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/PrivateHeaders/TopLevelPrivateKit_Private.apinotes
@@ -1,0 +1,4 @@
+Name: TopLevelPrivateKit_Private
+Globals:
+- Name: TopLevelPrivateKit_Private
+  Type: float

--- a/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/PrivateHeaders/TopLevelPrivateKit_Private.h
+++ b/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/PrivateHeaders/TopLevelPrivateKit_Private.h
@@ -1,0 +1,1 @@
+extern int TopLevelPrivateKit_Private;

--- a/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/PrivateHeaders/TopLevelPrivateKit_Private_private.apinotes
+++ b/test/APINotes/Inputs/Frameworks/TopLevelPrivateKit.framework/PrivateHeaders/TopLevelPrivateKit_Private_private.apinotes
@@ -1,0 +1,1 @@
+garbage here because this file shouldn't get read

--- a/test/APINotes/Inputs/Headers/PrivateLib.apinotes
+++ b/test/APINotes/Inputs/Headers/PrivateLib.apinotes
@@ -1,0 +1,4 @@
+Name: HeaderLib
+Globals:
+- Name: PrivateLib
+  Type: float

--- a/test/APINotes/Inputs/Headers/PrivateLib.h
+++ b/test/APINotes/Inputs/Headers/PrivateLib.h
@@ -1,0 +1,1 @@
+extern int PrivateLib;

--- a/test/APINotes/Inputs/Headers/PrivateLib_private.apinotes
+++ b/test/APINotes/Inputs/Headers/PrivateLib_private.apinotes
@@ -1,0 +1,1 @@
+garbage here because this file shouldn't get read

--- a/test/APINotes/Inputs/Headers/module.private.modulemap
+++ b/test/APINotes/Inputs/Headers/module.private.modulemap
@@ -1,0 +1,3 @@
+module PrivateLib {
+  header "PrivateLib.h"
+}

--- a/test/APINotes/top-level-private-modules.c
+++ b/test/APINotes/top-level-private-modules.c
@@ -1,0 +1,8 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules -Wno-private-module -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -verify
+
+#include <PrivateLib.h>
+#include <TopLevelPrivateKit/TopLevelPrivateKit_Private.h>
+
+void *testPlain = PrivateLib; // expected-error {{initializing 'void *' with an expression of incompatible type 'float'}}
+void *testFramework = TopLevelPrivateKit_Private; // expected-error {{initializing 'void *' with an expression of incompatible type 'float'}}


### PR DESCRIPTION
This is most important for frameworks: we want to look for PrivateHeaders/Bar.apinotes rather than Headers/Bar.apinotes and PrivateHeaders/Bar_private.apinotes. (This is especially important because 'Bar' is probably actually something like 'FooKit_Private' in practice.)

Doing this means keeping track of whether a particular module came from a "private" module map. Right now that's just being done by checking the name of the module map file; we could switch to something more principled in the future if it matters.

Note that the naming convention of 'FooKit_Private' for a private top-level module may cause certain API notes files to be loaded twice on case-insensitive filesystems: once as the regular API notes for 'FooKit_Private', and once as the *private* API notes for 'FooKit'. However, this shouldn't be a problem in practice (other than a bit of extra I/O) because (1) most declarations will only show up in one of the two modules anyway, being ignored in the other, and (2) the API notes we have are /mostly/ idempotent (except for how they record replacements).

(There is a Name field in an API notes file, but it's not currently validated.)

rdar://problem/39417625