### PR TITLE
Add a new attribute swift_bridged_typedef for typedef bridging.

### DIFF
--- a/include/clang/Basic/Attr.td
+++ b/include/clang/Basic/Attr.td
@@ -1743,6 +1743,13 @@ def SwiftBridge : Attr {
   let Documentation = [SwiftBridgeDocs];
 }
 
+def SwiftBridgedTypedef : Attr {
+  let Spellings = [GNU<"swift_bridged_typedef">];
+  let Subjects = SubjectList<[TypedefName], ErrorDiag, "typedefs">;
+  let Args = [];
+  let Documentation = [SwiftBridgedTypedefDocs];
+}
+
 def SwiftObjCMembers : Attr {
   let Spellings = [GNU<"swift_objc_members">];
   let Subjects = SubjectList<[ObjCInterface], ErrorDiag>;

--- a/include/clang/Basic/AttrDocs.td
+++ b/include/clang/Basic/AttrDocs.td
@@ -2743,6 +2743,13 @@ The ``swift_bridge`` attribute indicates that the type to which the attribute ap
   }];
 }
 
+def SwiftBridgedTypedefDocs : Documentation {
+  let Category = SwiftDocs;
+  let Content = [{
+The ``swift_bridged_typedef`` attribute indicates that, when the typedef to which the attribute appertains is imported into Swift, it should refer to the bridged Swift type (e.g., Swift's ``String``) rather than the Objective-C type as written (e.g., ``NSString``).
+  }];
+}
+
 def SwiftObjCMembersDocs : Documentation {
   let Category = SwiftDocs;
   let Content = [{

--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -6916,6 +6916,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case AttributeList::AT_SwiftBridge:
     handleSwiftBridgeAttr(S, D, AL);
     break;
+  case AttributeList::AT_SwiftBridgedTypedef:
+    handleSimpleAttribute<SwiftBridgedTypedefAttr>(S, D, Attr);
+    break;
   case AttributeList::AT_SwiftObjCMembers:
     handleSimpleAttribute<SwiftObjCMembersAttr>(S, D, AL);
     break;

--- a/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -2,8 +2,8 @@
 
 // The number of supported attributes should never go down!
 
-// Swift has 3 additional attributes
-// CHECK: #pragma clang attribute supports 71 attributes:
+// Swift has 7 additional attributes
+// CHECK: #pragma clang attribute supports 72 attributes:
 // CHECK-NEXT: AMDGPUFlatWorkGroupSize (SubjectMatchRule_function)
 // CHECK-NEXT: AMDGPUNumSGPR (SubjectMatchRule_function)
 // CHECK-NEXT: AMDGPUNumVGPR (SubjectMatchRule_function)
@@ -62,6 +62,7 @@
 // CHECK-NEXT: ReturnsNonNull (SubjectMatchRule_objc_method, SubjectMatchRule_function)
 // CHECK-NEXT: Section (SubjectMatchRule_function, SubjectMatchRule_variable_is_global, SubjectMatchRule_objc_method, SubjectMatchRule_objc_property)
 // CHECK-NEXT: SetTypestate (SubjectMatchRule_function_is_member)
+// CHECK-NEXT: SwiftBridgedTypedef (SubjectMatchRule_type_alias)
 // CHECK-NEXT: SwiftContext (SubjectMatchRule_variable_is_parameter)
 // CHECK-NEXT: SwiftError (SubjectMatchRule_function, SubjectMatchRule_objc_method)
 // CHECK-NEXT: SwiftErrorResult (SubjectMatchRule_variable_is_parameter)

--- a/test/SemaObjC/attr-swift.m
+++ b/test/SemaObjC/attr-swift.m
@@ -215,3 +215,11 @@ extern void *wilma4(void) __attribute__((swift_error(zero_result))); // expected
 
 
 extern _Bool suzanne __attribute__((swift_error(none))); // expected-error {{'swift_error' attribute only applies to functions and Objective-C methods}}
+
+// --- swift_bridged_typedef ---
+@interface NSString
+@end
+
+typedef NSString *NSMyAmazingStringAlias __attribute__((swift_bridged_typedef));
+
+struct __attribute__((swift_bridged_typedef)) NotATypedef { }; // expected-error{{'swift_bridged_typedef' attribute only applies to typedefs}}


### PR DESCRIPTION
When importing a typedef of a bridged type, Swift will use the
typedef-name to describe the unbridging version of the type (e.g.,
NSString). This attribute signals when Swift should instead import the
typedef using the bridged type (e.g., Swift's String).

Clang side of rdar://problem/39497900.