### PR TITLE
Fix addition of swift_bridged_typedef attribute.

### DIFF
--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -6917,7 +6917,7 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     handleSwiftBridgeAttr(S, D, AL);
     break;
   case AttributeList::AT_SwiftBridgedTypedef:
-    handleSimpleAttribute<SwiftBridgedTypedefAttr>(S, D, Attr);
+    handleSimpleAttribute<SwiftBridgedTypedefAttr>(S, D, AL);
     break;
   case AttributeList::AT_SwiftObjCMembers:
     handleSimpleAttribute<SwiftObjCMembersAttr>(S, D, AL);


### PR DESCRIPTION
Cope with a renaming upstream that I hadn't noticed before.