### PR TITLE
upstream-update: adjust for SVN r331155

### DIFF
--- a/lib/Edit/FillInMissingProtocolStubs.cpp
+++ b/lib/Edit/FillInMissingProtocolStubs.cpp
@@ -248,12 +248,12 @@ public:
       return SourceLocation();
     SourceLocation Loc = MethodsFromProtocolInContainer[0]->getLocEnd();
     if (Loc.isMacroID())
-      Loc = SM.getExpansionRange(Loc).second;
+      Loc = SM.getExpansionRange(Loc).getEnd();
     for (const ObjCMethodDecl *M :
          makeArrayRef(MethodsFromProtocolInContainer).drop_front()) {
       SourceLocation EndLoc = M->getLocEnd();
       if (EndLoc.isMacroID())
-        EndLoc = SM.getExpansionRange(EndLoc).second;
+        EndLoc = SM.getExpansionRange(EndLoc).getEnd();
       if (SM.isBeforeInTranslationUnit(Loc, EndLoc))
         Loc = EndLoc;
     }

--- a/lib/Tooling/Refactor/Extract.cpp
+++ b/lib/Tooling/Refactor/Extract.cpp
@@ -306,8 +306,9 @@ initiateAnyExtractOperation(ASTSlice &Slice, ASTContext &Context,
         Context.getSourceManager().isMacroArgExpansion(Range.getEnd()))
       Range.setEnd(Context.getSourceManager().getSpellingLoc(Range.getEnd()));
     else
-      Range.setEnd(
-          Context.getSourceManager().getExpansionRange(Range.getEnd()).second);
+      Range.setEnd(Context.getSourceManager()
+                       .getExpansionRange(Range.getEnd())
+                       .getEnd());
   }
   CandidateExtractionInfo.push_back(ExtractOperation::CandidateInfo(Range));
   Result.RefactoringOp = std::move(Operation);

--- a/lib/Tooling/Refactor/FillInMissingMethodStubsFromAbstractClasses.cpp
+++ b/lib/Tooling/Refactor/FillInMissingMethodStubsFromAbstractClasses.cpp
@@ -163,7 +163,7 @@ static SourceLocation findInsertionLocationForMethodsFromAbstractClass(
       if (OM->getLexicalDeclContext() == AbstractClass) {
         SourceLocation EndLoc = M->getLocEnd();
         if (EndLoc.isMacroID())
-          EndLoc = SM.getExpansionRange(EndLoc).second;
+          EndLoc = SM.getExpansionRange(EndLoc).getEnd();
         if (Loc.isInvalid())
           Loc = EndLoc;
         else if (SM.isBeforeInTranslationUnit(Loc, EndLoc))

--- a/lib/Tooling/Refactor/ImplementDeclaredMethods.cpp
+++ b/lib/Tooling/Refactor/ImplementDeclaredMethods.cpp
@@ -254,7 +254,7 @@ ImplementDeclaredCXXMethodsOperation::runInImplementationAST(
   NestedNameSpecifier *NamePrefix = nullptr;
   if (DefinedOutOfLineMethods.empty()) {
     const RecordDecl *OutermostRecord = findOutermostRecord(Class);
-    InsertionLoc = SM.getExpansionRange(OutermostRecord->getLocEnd()).second;
+    InsertionLoc = SM.getExpansionRange(OutermostRecord->getLocEnd()).getEnd();
     if (SM.getFileID(InsertionLoc) == File) {
       // We can insert right after the class. Compute the appropriate
       // qualification.
@@ -297,7 +297,7 @@ ImplementDeclaredCXXMethodsOperation::runInImplementationAST(
   } else {
     // Insert at the end of the defined methods.
     for (const CXXMethodDecl *M : DefinedOutOfLineMethods) {
-      SourceLocation EndLoc = SM.getExpansionRange(M->getLocEnd()).second;
+      SourceLocation EndLoc = SM.getExpansionRange(M->getLocEnd()).getEnd();
       if (InsertionLoc.isInvalid() ||
           SM.isBeforeInTranslationUnit(InsertionLoc, EndLoc)) {
         InsertionLoc = EndLoc;


### PR DESCRIPTION
The `CharSourceRange` now requires the use of `getBegin()` and
`getEnd()` instead.