### PR TITLE
[test] Disable some API notes tests broken by upstream changes

### DIFF
--- a/test/APINotes/retain-count-convention.m
+++ b/test/APINotes/retain-count-convention.m
@@ -2,6 +2,10 @@
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules  -fdisable-module-hash -fsyntax-only -F %S/Inputs/Frameworks %s
 // RUN: %clang_cc1 -ast-print %t/ModulesCache/SimpleKit.pcm | FileCheck %s
 
+// REQUIRES: rdar40296113
+// This test relies on -ast-print including implicit attributes, but it no
+// longer does that as of https://reviews.llvm.org/D46894.
+
 #import <SimpleKit/SimpleKit.h>
 
 // CHECK: void *getCFOwnedToUnowned() __attribute__((cf_returns_not_retained));

--- a/test/APINotes/types.m
+++ b/test/APINotes/types.m
@@ -2,6 +2,10 @@
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules -Wno-private-module -fdisable-module-hash -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -verify
 // RUN: %clang_cc1 -ast-print %t/ModulesCache/SimpleKit.pcm | FileCheck %s
 
+// REQUIRES: rdar40296113
+// This test relies on -ast-print including implicit attributes, but it no
+// longer does that as of https://reviews.llvm.org/D46894.
+
 #import <SomeKit/SomeKit.h>
 #import <SimpleKit/SimpleKit.h>
 

--- a/test/APINotes/versioned-multi.c
+++ b/test/APINotes/versioned-multi.c
@@ -14,6 +14,10 @@
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Versioned5 -fdisable-module-hash -fapinotes-modules -fapinotes-swift-version=5 -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s
 // RUN: %clang_cc1 -ast-print %t/ModulesCache/Versioned5/VersionedKit.pcm | FileCheck -check-prefix=CHECK-VERSIONED-5 %s
 
+// REQUIRES: rdar40296113
+// This test relies on -ast-print including implicit attributes, but it no
+// longer does that as of https://reviews.llvm.org/D46894.
+
 #import <VersionedKit/VersionedKit.h>
 
 // CHECK-UNVERSIONED: typedef int MultiVersionedTypedef4;

--- a/test/APINotes/versioned.m
+++ b/test/APINotes/versioned.m
@@ -10,6 +10,10 @@
 // RUN: %clang_cc1 -ast-print %t/ModulesCache/Versioned/VersionedKit.pcm | FileCheck -check-prefix=CHECK-VERSIONED %s
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Versioned -fdisable-module-hash -fapinotes-modules  -fapinotes-swift-version=3 -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter 'DUMP' | FileCheck -check-prefix=CHECK-DUMP -check-prefix=CHECK-VERSIONED-DUMP %s
 
+// REQUIRES: rdar40296113
+// This test relies on -ast-print including implicit attributes, but it no
+// longer does that as of https://reviews.llvm.org/D46894.
+
 #import <VersionedKit/VersionedKit.h>
 
 // CHECK-UNVERSIONED: void moveToPointDUMP(double x, double y) __attribute__((swift_name("moveTo(x:y:)")));


### PR DESCRIPTION
These test rely on `-ast-print` including implicit attributes, but it no longer does that as of https://reviews.llvm.org/D46894.

Tracked by rdar://problem/40296113.