### PR TITLE
[4.2] [APINotes] Warn when a private API notes file uses the wrong case

### DIFF
--- a/include/clang/Basic/DiagnosticCommonKinds.td
+++ b/include/clang/Basic/DiagnosticCommonKinds.td
@@ -237,6 +237,14 @@ def err_apinotes_message : Error<"%0">;
 def warn_apinotes_message : Warning<"%0">, InGroup<DiagGroup<"apinotes">>;
 def note_apinotes_message : Note<"%0">;
 
+class NonportablePrivateAPINotesPath  : Warning<
+  "private API notes file for module '%0' should be named "
+  "'%0_private.apinotes', not '%1'">;
+def warn_apinotes_private_case : NonportablePrivateAPINotesPath,
+  InGroup<DiagGroup<"nonportable-private-apinotes-path">>;
+def warn_apinotes_private_case_system : NonportablePrivateAPINotesPath, 
+  DefaultIgnore, InGroup<DiagGroup<"nonportable-private-system-apinotes-path">>;
+
 // OpenMP
 def err_omp_more_one_clause : Error<
   "directive '#pragma omp %0' cannot contain more than one '%1' clause%select{| with '%3' name modifier| with 'source' dependence}2">;

--- a/lib/APINotes/APINotesManager.cpp
+++ b/lib/APINotes/APINotesManager.cpp
@@ -15,6 +15,7 @@
 #include "clang/APINotes/APINotesOptions.h"
 #include "clang/APINotes/APINotesReader.h"
 #include "clang/APINotes/APINotesYAMLCompiler.h"
+#include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticIDs.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/LangOptions.h"
@@ -163,7 +164,7 @@ const FileEntry *APINotesManager::findAPINotesFile(const DirectoryEntry *directo
   // Look for a binary API notes file.
   llvm::sys::path::append(path, 
     llvm::Twine(basename) + basenameSuffix + "." + BINARY_APINOTES_EXTENSION);
-  if (const FileEntry *binaryFile = fileMgr.getFile(path))
+  if (const FileEntry *binaryFile = fileMgr.getFile(path, /*Open*/true))
     return binaryFile;
 
   // Go back to the original path.
@@ -172,7 +173,7 @@ const FileEntry *APINotesManager::findAPINotesFile(const DirectoryEntry *directo
   // Look for the source API notes file.
   llvm::sys::path::append(path, 
     llvm::Twine(basename) + basenameSuffix + "." + SOURCE_APINOTES_EXTENSION);
-  return fileMgr.getFile(path);
+  return fileMgr.getFile(path, /*Open*/true);
 }
 
 const DirectoryEntry *APINotesManager::loadFrameworkAPINotes(
@@ -225,6 +226,25 @@ const DirectoryEntry *APINotesManager::loadFrameworkAPINotes(
   return HeaderDir;
 }
 
+static void checkPrivateAPINotesName(DiagnosticsEngine &diags,
+                                     const FileEntry *file,
+                                     const Module *module) {
+  if (file->tryGetRealPathName().empty())
+    return;
+
+  StringRef realFilename =
+      llvm::sys::path::filename(file->tryGetRealPathName());
+  StringRef realStem = llvm::sys::path::stem(realFilename);
+  if (realStem.endswith("_private"))
+    return;
+
+  unsigned diagID = diag::warn_apinotes_private_case;
+  if (module->IsSystem)
+    diagID = diag::warn_apinotes_private_case_system;
+
+  diags.Report(SourceLocation(), diagID) << module->Name << realFilename;
+}
+
 bool APINotesManager::loadCurrentModuleAPINotes(
                    const Module *module,
                    bool lookInModule,
@@ -245,6 +265,9 @@ bool APINotesManager::loadCurrentModuleAPINotes(
       if (auto file = findAPINotesFile(dir, moduleName, wantPublic)) {
         foundAny = true;
 
+        if (!wantPublic)
+          checkPrivateAPINotesName(SourceMgr.getDiagnostics(), file, module);
+
         // Try to load the API notes file.
         CurrentModuleReaders[numReaders] = loadAPINotes(file).release();
         if (CurrentModuleReaders[numReaders])
@@ -258,7 +281,7 @@ bool APINotesManager::loadCurrentModuleAPINotes(
       //
       // Public modules:
       // - Headers/Foo.apinotes
-      // - PrivateHeaders/Foo_Private.apinotes
+      // - PrivateHeaders/Foo_private.apinotes
       // Private modules:
       // - PrivateHeaders/Bar.apinotes (except that 'Bar' probably already has
       //   the word "Private" in it in practice)
@@ -283,7 +306,7 @@ bool APINotesManager::loadCurrentModuleAPINotes(
     } else {
       // Public modules:
       // - Foo.apinotes
-      // - Foo_Private.apinotes
+      // - Foo_private.apinotes
       // Private modules:
       // - Bar.apinotes (except that 'Bar' probably already has the word
       //   "Private" in it in practice)

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCasePrivate.framework/Headers/FrameworkWithWrongCasePrivate.h
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCasePrivate.framework/Headers/FrameworkWithWrongCasePrivate.h
@@ -1,0 +1,1 @@
+extern int FrameworkWithWrongCasePrivate;

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCasePrivate.framework/Modules/module.modulemap
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCasePrivate.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module FrameworkWithWrongCasePrivate {
+  umbrella header "FrameworkWithWrongCasePrivate.h"
+  export *
+  module * { export * }
+}

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCasePrivate.framework/PrivateHeaders/FrameworkWithWrongCasePrivate_Private.apinotes
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCasePrivate.framework/PrivateHeaders/FrameworkWithWrongCasePrivate_Private.apinotes
@@ -1,0 +1,1 @@
+Name: FrameworkWithWrongCasePrivate

--- a/test/APINotes/Inputs/Headers/ModuleWithWrongCasePrivate.h
+++ b/test/APINotes/Inputs/Headers/ModuleWithWrongCasePrivate.h
@@ -1,0 +1,1 @@
+extern int ModuleWithWrongCase;

--- a/test/APINotes/Inputs/Headers/ModuleWithWrongCasePrivate_Private.apinotes
+++ b/test/APINotes/Inputs/Headers/ModuleWithWrongCasePrivate_Private.apinotes
@@ -1,0 +1,1 @@
+Name: ModuleWithWrongCasePrivate

--- a/test/APINotes/Inputs/Headers/module.modulemap
+++ b/test/APINotes/Inputs/Headers/module.modulemap
@@ -5,3 +5,7 @@ module HeaderLib {
 module BrokenTypes {
   header "BrokenTypes.h"
 }
+
+module ModuleWithWrongCasePrivate {
+  header "ModuleWithWrongCasePrivate.h"
+}

--- a/test/APINotes/case-for-private-apinotes-file.c
+++ b/test/APINotes/case-for-private-apinotes-file.c
@@ -1,0 +1,16 @@
+// REQUIRES: case-insensitive-filesystem
+
+// RUN: rm -rf %t
+// RUN: %clang_cc1 -fsyntax-only -fmodules -fapinotes-modules -fimplicit-module-maps -fmodules-cache-path=%t -F %S/Inputs/Frameworks -I %S/Inputs/Headers %s 2>&1 | FileCheck %s
+
+// RUN: rm -rf %t
+// RUN: %clang_cc1 -fsyntax-only -fmodules -fapinotes-modules -fimplicit-module-maps -fmodules-cache-path=%t -iframework %S/Inputs/Frameworks -isystem %S/Inputs/Headers %s -Werror
+
+// RUN: rm -rf %t
+// RUN: %clang_cc1 -fsyntax-only -fmodules -fapinotes-modules -fimplicit-module-maps -fmodules-cache-path=%t -iframework %S/Inputs/Frameworks -isystem %S/Inputs/Headers %s -Wnonportable-private-system-apinotes-path 2>&1 | FileCheck %s
+
+#include <ModuleWithWrongCasePrivate.h>
+#include <FrameworkWithWrongCasePrivate/FrameworkWithWrongCasePrivate.h>
+
+// CHECK: warning: private API notes file for module 'ModuleWithWrongCasePrivate' should be named 'ModuleWithWrongCasePrivate_private.apinotes', not 'ModuleWithWrongCasePrivate_Private.apinotes'
+// CHECK: warning: private API notes file for module 'FrameworkWithWrongCasePrivate' should be named 'FrameworkWithWrongCasePrivate_private.apinotes', not 'FrameworkWithWrongCasePrivate_Private.apinotes'


### PR DESCRIPTION
- **Explanation**: Private API notes files for a module "FooKit" are found under the name "FooKit_private.apinotes". On a case-insensitive filesystem, this can be found under the name "FooKit_Private.apinotes"—a reasonable mistake! But one that causes problems on case-sensitive filesystems. Catch this common mistake with a warning.

- **Scope**: Only affects modules with private API notes.

- **Issue**: rdar://problem/39914779

- **Risk**: Low. This is a warning unrelated to pretty much everything else, and it only has a narrow scope anyway.

- **Testing**: Added a compiler regression test.

- **Reviewed by**: @DougGregor
