### PR TITLE
Adjust for Clang r332598: VersionTuple always uses dots now

### DIFF
--- a/lib/APINotes/APINotesWriter.cpp
+++ b/lib/APINotes/APINotesWriter.cpp
@@ -437,7 +437,6 @@ namespace {
     else if (version.getSubminor()) descriptor = 2;
     else if (version.getMinor()) descriptor = 1;
     else descriptor = 0;
-    assert(!version.usesUnderscores() && "Not a serializable version");
     writer.write<uint8_t>(descriptor);
 
     // Write the components.

--- a/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -439,8 +439,6 @@ namespace llvm {
         if (value.tryParse(scalar))
           return "not a version number in the form XX.YY";
 
-        // Canonicalize on '.' as a separator.
-        value.UseDotAsSeparator();
         return StringRef();
       }
 


### PR DESCRIPTION
Remove references to the usesUnderscores() and UseDotAsSeparator()
functions that are no longer needed.