### PR TITLE
[upstream-with-swift] Increase DIAG_SIZE_FRONTEND to 101

### DIFF
--- a/include/clang/Basic/DiagnosticIDs.h
+++ b/include/clang/Basic/DiagnosticIDs.h
@@ -30,7 +30,7 @@ namespace clang {
     enum {
       DIAG_SIZE_COMMON        =  300,
       DIAG_SIZE_DRIVER        =  200,
-      DIAG_SIZE_FRONTEND      =  100,
+      DIAG_SIZE_FRONTEND      =  101, // swift-clang has 1 extra diag
       DIAG_SIZE_SERIALIZATION =  120,
       DIAG_SIZE_LEX           =  400,
       DIAG_SIZE_PARSE         =  500,


### PR DESCRIPTION
The swift-clang/upstream-with-swift branch currently has 1 extra diag
compared to upstream Clang. It looks like upstream is now right at that
limit of 100, so the swift-clang version is failing. I'm expecting the
upstream version to bump up the limit soon (i.e., the next time someone
tries to add a frontend diagnostic) but it would be good to keep this
version higher by 1.