### PR TITLE
[4.2] [APINotes] Don't apply API notes to @class / forward @protocol decls

### DIFF
--- a/lib/Sema/SemaDeclObjC.cpp
+++ b/lib/Sema/SemaDeclObjC.cpp
@@ -1754,7 +1754,6 @@ Sema::ActOnForwardProtocolDeclaration(SourceLocation AtProtocolLoc,
       = ObjCProtocolDecl::Create(Context, CurContext, Ident, 
                                  IdentPair.second, AtProtocolLoc,
                                  PrevDecl);
-    ProcessAPINotes(PDecl);
 
     PushOnScopeChains(PDecl, TUScope);
     CheckObjCDeclScope(PDecl);
@@ -1762,7 +1761,6 @@ Sema::ActOnForwardProtocolDeclaration(SourceLocation AtProtocolLoc,
     if (attrList)
       ProcessDeclAttributeList(TUScope, PDecl, attrList);
     AddPragmaAttributes(TUScope, PDecl);
-    ProcessAPINotes(PDecl);
 
     if (PrevDecl)
       mergeDeclAttributes(PDecl, PrevDecl);
@@ -3138,7 +3136,6 @@ Sema::ActOnForwardClassDeclaration(SourceLocation AtClassLoc,
                                   ClassName, TypeParams, PrevIDecl,
                                   IdentLocs[i]);
     IDecl->setAtEndRange(IdentLocs[i]);
-    ProcessAPINotes(IDecl);
 
     PushOnScopeChains(IDecl, TUScope);
     CheckObjCDeclScope(IDecl);

--- a/test/APINotes/Inputs/Frameworks/LayeredKit.framework/Headers/LayeredKit.h
+++ b/test/APINotes/Inputs/Frameworks/LayeredKit.framework/Headers/LayeredKit.h
@@ -1,0 +1,11 @@
+@import LayeredKitImpl;
+
+// @interface declarations already don't inherit attributes from forward 
+// declarations, so in order to test this properly we have to /not/ define
+// UpwardClass anywhere.
+
+// @interface UpwardClass
+// @end
+
+@protocol UpwardProto
+@end

--- a/test/APINotes/Inputs/Frameworks/LayeredKit.framework/Modules/module.modulemap
+++ b/test/APINotes/Inputs/Frameworks/LayeredKit.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module LayeredKit {
+  umbrella header "LayeredKit.h"
+  export *
+  module * { export * }
+}

--- a/test/APINotes/Inputs/Frameworks/LayeredKitImpl.framework/Headers/LayeredKitImpl.apinotes
+++ b/test/APINotes/Inputs/Frameworks/LayeredKitImpl.framework/Headers/LayeredKitImpl.apinotes
@@ -1,0 +1,9 @@
+Name: LayeredKitImpl
+Classes:
+- Name: PerfectlyNormalClass
+  Availability: none
+- Name: UpwardClass
+  Availability: none
+Protocols:
+- Name: UpwardProto
+  Availability: none

--- a/test/APINotes/Inputs/Frameworks/LayeredKitImpl.framework/Headers/LayeredKitImpl.h
+++ b/test/APINotes/Inputs/Frameworks/LayeredKitImpl.framework/Headers/LayeredKitImpl.h
@@ -1,0 +1,7 @@
+@protocol UpwardProto;
+@class UpwardClass;
+
+@interface PerfectlyNormalClass
+@end
+
+void doImplementationThings(UpwardClass *first, id <UpwardProto> second) __attribute((unavailable));

--- a/test/APINotes/Inputs/Frameworks/LayeredKitImpl.framework/Modules/module.modulemap
+++ b/test/APINotes/Inputs/Frameworks/LayeredKitImpl.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module LayeredKitImpl {
+  umbrella header "LayeredKitImpl.h"
+  export *
+  module * { export * }
+}

--- a/test/APINotes/objc-forward-declarations.m
+++ b/test/APINotes/objc-forward-declarations.m
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules -fsyntax-only -F %S/Inputs/Frameworks %s -verify
+
+@import LayeredKit;
+
+void test(
+  UpwardClass *okayClass,
+  id <UpwardProto> okayProto,
+  PerfectlyNormalClass *badClass // expected-error {{'PerfectlyNormalClass' is unavailable}}
+) {
+  // expected-note@LayeredKitImpl/LayeredKitImpl.h:4 {{'PerfectlyNormalClass' has been explicitly marked unavailable here}}
+}


### PR DESCRIPTION
- **Explanation**: Normally Swift ignores forward declarations of Objective-C classes, but SourceKit's module interface generation feature makes dummy ClassDecls for them instead. This exposes an issue where we allowed API notes to be placed on those forward declarations, even though the module may not own the types in question. This led to crashes in other parts of the Swift compiler that weren't expecting the attributes that API notes provide. This change sidesteps the whole issue by not allowing API notes to apply to forward declarations of Objective-C classes or protocols, consistent with a similar change made for structs, enums, and unions last year.

- **Scope**: Only affects classes and protocols with API notes, and even then only the forward declarations thereof.

- **Issue**: rdar://problem/40278479

- **Risk**: Low. This only affects SourceKit, and only for classes that didn't have definitions elsewhere where someone actually tried (perhaps accidentally) to use API notes anyway.

- **Testing**: Added compiler regression tests, verified that the SourceKit request works successfully. I also plan to add a Swift-side test on the master branch.

- **Reviewed by**: @DougGregor