### PR TITLE
Fix a bad merge conflict resolution

### DIFF
--- a/lib/Sema/SemaDeclObjC.cpp
+++ b/lib/Sema/SemaDeclObjC.cpp
@@ -2191,7 +2191,7 @@ void Sema::CheckImplementationIvars(ObjCImplementationDecl *ImpDecl,
 
 static bool shouldWarnUndefinedMethod(const ObjCMethodDecl *M) {
   // No point warning no definition of method which is 'unavailable'.
-  return method->getAvailability() != AR_Unavailable;
+  return M->getAvailability() != AR_Unavailable;
 }
 
 static void WarnUndefinedMethod(Sema &S, SourceLocation ImpLoc,


### PR DESCRIPTION
The upstream-with-swift branch has refactored some code into a separate
function where the "method" parameter is named "M", but the conflict was
resolved without adjusting the name.