### PR TITLE
[5.0] [APINotes] API-noted attributes should not be implicit

### DIFF
--- a/test/APINotes/properties.m
+++ b/test/APINotes/properties.m
@@ -9,36 +9,36 @@
 @import VersionedKit;
 
 // CHECK-LABEL: ObjCPropertyDecl {{.+}} accessorsOnly 'id'
-// CHECK-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} Implicit
+// CHECK-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} <<invalid sloc>>
 // CHECK-NOT: Attr
 
 // CHECK-LABEL: ObjCPropertyDecl {{.+}} accessorsOnlyForClass 'id'
-// CHECK-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} Implicit
+// CHECK-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} <<invalid sloc>>
 // CHECK-NOT: Attr
 
 // CHECK-LABEL: ObjCPropertyDecl {{.+}} accessorsOnlyInVersion3 'id'
-// CHECK-3-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} Implicit
+// CHECK-3-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} <<invalid sloc>>
 // CHECK-4-NEXT: SwiftVersionedAttr {{.+}} 3.0{{$}}
-// CHECK-4-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} Implicit
+// CHECK-4-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} <<invalid sloc>>
 // CHECK-NOT: Attr
 
 // CHECK-LABEL: ObjCPropertyDecl {{.+}} accessorsOnlyForClassInVersion3 'id'
-// CHECK-3-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} Implicit
+// CHECK-3-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} <<invalid sloc>>
 // CHECK-4-NEXT: SwiftVersionedAttr {{.+}} 3.0{{$}}
-// CHECK-4-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} Implicit
+// CHECK-4-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} <<invalid sloc>>
 // CHECK-NOT: Attr
 
 // CHECK-LABEL: ObjCPropertyDecl {{.+}} accessorsOnlyExceptInVersion3 'id'
 // CHECK-3-NEXT: SwiftVersionedAttr {{.+}} Implicit 3.0 IsReplacedByActive{{$}}
-// CHECK-3-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} Implicit
-// CHECK-4-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} Implicit
+// CHECK-3-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} <<invalid sloc>>
+// CHECK-4-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} <<invalid sloc>>
 // CHECK-4-NEXT: SwiftVersionedRemovalAttr {{.+}} Implicit 3.0 {{[0-9]+}}
 // CHECK-NOT: Attr
 
 // CHECK-LABEL: ObjCPropertyDecl {{.+}} accessorsOnlyForClassExceptInVersion3 'id'
 // CHECK-3-NEXT: SwiftVersionedAttr {{.+}} Implicit 3.0 IsReplacedByActive{{$}}
-// CHECK-3-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} Implicit
-// CHECK-4-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} Implicit
+// CHECK-3-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} <<invalid sloc>>
+// CHECK-4-NEXT: SwiftImportPropertyAsAccessorsAttr {{.+}} <<invalid sloc>>
 // CHECK-4-NEXT: SwiftVersionedRemovalAttr {{.+}} Implicit 3.0 {{[0-9]+}}
 // CHECK-NOT: Attr
 

--- a/test/APINotes/retain-count-convention.m
+++ b/test/APINotes/retain-count-convention.m
@@ -2,10 +2,6 @@
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules  -fdisable-module-hash -fsyntax-only -F %S/Inputs/Frameworks %s
 // RUN: %clang_cc1 -ast-print %t/ModulesCache/SimpleKit.pcm | FileCheck %s
 
-// REQUIRES: rdar40296113
-// This test relies on -ast-print including implicit attributes, but it no
-// longer does that as of https://reviews.llvm.org/D46894.
-
 #import <SimpleKit/SimpleKit.h>
 
 // CHECK: void *getCFOwnedToUnowned() __attribute__((cf_returns_not_retained));

--- a/test/APINotes/types.m
+++ b/test/APINotes/types.m
@@ -2,10 +2,6 @@
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules -Wno-private-module -fdisable-module-hash -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -verify
 // RUN: %clang_cc1 -ast-print %t/ModulesCache/SimpleKit.pcm | FileCheck %s
 
-// REQUIRES: rdar40296113
-// This test relies on -ast-print including implicit attributes, but it no
-// longer does that as of https://reviews.llvm.org/D46894.
-
 #import <SomeKit/SomeKit.h>
 #import <SimpleKit/SimpleKit.h>
 

--- a/test/APINotes/versioned-multi.c
+++ b/test/APINotes/versioned-multi.c
@@ -14,10 +14,6 @@
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Versioned5 -fdisable-module-hash -fapinotes-modules -fapinotes-swift-version=5 -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s
 // RUN: %clang_cc1 -ast-print %t/ModulesCache/Versioned5/VersionedKit.pcm | FileCheck -check-prefix=CHECK-VERSIONED-5 %s
 
-// REQUIRES: rdar40296113
-// This test relies on -ast-print including implicit attributes, but it no
-// longer does that as of https://reviews.llvm.org/D46894.
-
 #import <VersionedKit/VersionedKit.h>
 
 // CHECK-UNVERSIONED: typedef int MultiVersionedTypedef4;

--- a/test/APINotes/versioned.m
+++ b/test/APINotes/versioned.m
@@ -10,10 +10,6 @@
 // RUN: %clang_cc1 -ast-print %t/ModulesCache/Versioned/VersionedKit.pcm | FileCheck -check-prefix=CHECK-VERSIONED %s
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Versioned -fdisable-module-hash -fapinotes-modules  -fapinotes-swift-version=3 -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter 'DUMP' | FileCheck -check-prefix=CHECK-DUMP -check-prefix=CHECK-VERSIONED-DUMP %s
 
-// REQUIRES: rdar40296113
-// This test relies on -ast-print including implicit attributes, but it no
-// longer does that as of https://reviews.llvm.org/D46894.
-
 #import <VersionedKit/VersionedKit.h>
 
 // CHECK-UNVERSIONED: void moveToPointDUMP(double x, double y) __attribute__((swift_name("moveTo(x:y:)")));
@@ -22,10 +18,10 @@
 // CHECK-DUMP-LABEL: Dumping moveToPointDUMP
 // CHECK-VERSIONED-DUMP: SwiftVersionedAttr {{.+}} Implicit 3.0 IsReplacedByActive{{$}}
 // CHECK-VERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} "moveTo(x:y:)"
-// CHECK-VERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} Implicit "moveTo(a:b:)"
+// CHECK-VERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} <<invalid sloc>> "moveTo(a:b:)"
 // CHECK-UNVERSIONED-DUMP: SwiftNameAttr {{.+}} "moveTo(x:y:)"
 // CHECK-UNVERSIONED-DUMP-NEXT: SwiftVersionedAttr {{.+}} Implicit 3.0{{$}}
-// CHECK-UNVERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} Implicit "moveTo(a:b:)"
+// CHECK-UNVERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} <<invalid sloc>> "moveTo(a:b:)"
 // CHECK-DUMP-NOT: Attr
 
 // CHECK-DUMP-LABEL: Dumping unversionedRenameDUMP
@@ -36,9 +32,9 @@
 // CHECK-DUMP-NOT: Attr
 
 // CHECK-DUMP-LABEL: Dumping TestGenericDUMP
-// CHECK-VERSIONED-DUMP: SwiftImportAsNonGenericAttr {{.+}} Implicit
+// CHECK-VERSIONED-DUMP: SwiftImportAsNonGenericAttr {{.+}} <<invalid sloc>>
 // CHECK-UNVERSIONED-DUMP: SwiftVersionedAttr {{.+}} Implicit 3.0{{$}}
-// CHECK-UNVERSIONED-DUMP-NEXT: SwiftImportAsNonGenericAttr {{.+}} Implicit
+// CHECK-UNVERSIONED-DUMP-NEXT: SwiftImportAsNonGenericAttr {{.+}} <<invalid sloc>>
 // CHECK-DUMP-NOT: Attr
 
 // CHECK-DUMP-LABEL: Dumping Swift3RenamedOnlyDUMP
@@ -46,7 +42,7 @@
 // CHECK-VERSIONED-DUMP-NEXT: SwiftVersionedRemovalAttr {{.+}} Implicit 3.0 {{[0-9]+}} IsReplacedByActive{{$}}
 // CHECK-VERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} "SpecialSwift3Name"
 // CHECK-UNVERSIONED-DUMP-NEXT: SwiftVersionedAttr {{.+}} Implicit 3.0{{$}}
-// CHECK-UNVERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} Implicit "SpecialSwift3Name"
+// CHECK-UNVERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} <<invalid sloc>> "SpecialSwift3Name"
 // CHECK-DUMP-NOT: Attr
 
 // CHECK-DUMP-LABEL: Dumping Swift3RenamedAlsoDUMP
@@ -56,7 +52,7 @@
 // CHECK-VERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} "SpecialSwift3Also"
 // CHECK-UNVERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} <line:{{.+}}, col:{{.+}}> "Swift4Name"
 // CHECK-UNVERSIONED-DUMP-NEXT: SwiftVersionedAttr {{.+}} Implicit 3.0{{$}}
-// CHECK-UNVERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} Implicit "SpecialSwift3Also"
+// CHECK-UNVERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} <<invalid sloc>> "SpecialSwift3Also"
 // CHECK-DUMP-NOT: Attr
 
 // CHECK-DUMP-LABEL: Dumping Swift4RenamedDUMP
@@ -64,7 +60,7 @@
 // CHECK-VERSIONED-DUMP-NEXT: SwiftVersionedRemovalAttr {{.+}} Implicit 4 {{[0-9]+}} IsReplacedByActive{{$}}
 // CHECK-VERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} "SpecialSwift4Name"
 // CHECK-UNVERSIONED-DUMP-NEXT: SwiftVersionedAttr {{.+}} Implicit 4{{$}}
-// CHECK-UNVERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} Implicit "SpecialSwift4Name"
+// CHECK-UNVERSIONED-DUMP-NEXT: SwiftNameAttr {{.+}} <<invalid sloc>> "SpecialSwift4Name"
 // CHECK-DUMP-NOT: Attr
 
 // CHECK-DUMP-NOT: Dumping
@@ -76,9 +72,9 @@
 
 // CHECK-UNVERSIONED: typedef double MyDoubleWrapper __attribute__((swift_wrapper("struct")));
 
-// CHECK-UNVERSIONED:      enum MyErrorCode {
+// CHECK-UNVERSIONED:      enum __attribute__((ns_error_domain(MyErrorDomain))) MyErrorCode {
 // CHECK-UNVERSIONED-NEXT:     MyErrorCodeFailed = 1
-// CHECK-UNVERSIONED-NEXT: } __attribute__((ns_error_domain(MyErrorDomain)));
+// CHECK-UNVERSIONED-NEXT: };
 
 // CHECK-UNVERSIONED: __attribute__((swift_bridge("MyValueType")))
 // CHECK-UNVERSIONED: @interface MyReferenceType
@@ -99,93 +95,93 @@
 // CHECK-VERSIONED-NOT: __attribute__((swift_objc_members)
 // CHECK-VERSIONED: @interface TestProperties
 
-// CHECK-UNVERSIONED-LABEL: enum FlagEnum {
+// CHECK-UNVERSIONED-LABEL: enum __attribute__((flag_enum)) FlagEnum {
 // CHECK-UNVERSIONED-NEXT:     FlagEnumA = 1,
 // CHECK-UNVERSIONED-NEXT:     FlagEnumB = 2
-// CHECK-UNVERSIONED-NEXT: } __attribute__((flag_enum));
-// CHECK-UNVERSIONED-LABEL: enum NewlyFlagEnum {
+// CHECK-UNVERSIONED-NEXT: };
+// CHECK-UNVERSIONED-LABEL: enum __attribute__((flag_enum)) NewlyFlagEnum {
 // CHECK-UNVERSIONED-NEXT:     NewlyFlagEnumA = 1,
 // CHECK-UNVERSIONED-NEXT:     NewlyFlagEnumB = 2
-// CHECK-UNVERSIONED-NEXT: } __attribute__((flag_enum));
-// CHECK-UNVERSIONED-LABEL: enum APINotedFlagEnum {
+// CHECK-UNVERSIONED-NEXT: };
+// CHECK-UNVERSIONED-LABEL: enum __attribute__((flag_enum)) APINotedFlagEnum {
 // CHECK-UNVERSIONED-NEXT:     APINotedFlagEnumA = 1,
 // CHECK-UNVERSIONED-NEXT:     APINotedFlagEnumB = 2
-// CHECK-UNVERSIONED-NEXT: } __attribute__((flag_enum));
-// CHECK-UNVERSIONED-LABEL: enum OpenEnum {
+// CHECK-UNVERSIONED-NEXT: };
+// CHECK-UNVERSIONED-LABEL: enum  __attribute__((enum_extensibility("open"))) OpenEnum {
 // CHECK-UNVERSIONED-NEXT:     OpenEnumA = 1
-// CHECK-UNVERSIONED-NEXT: } __attribute__((enum_extensibility("open")));
-// CHECK-UNVERSIONED-LABEL: enum NewlyOpenEnum {
+// CHECK-UNVERSIONED-NEXT: };
+// CHECK-UNVERSIONED-LABEL: enum  __attribute__((enum_extensibility("open"))) NewlyOpenEnum {
 // CHECK-UNVERSIONED-NEXT:     NewlyOpenEnumA = 1
-// CHECK-UNVERSIONED-NEXT: } __attribute__((enum_extensibility("open")));
-// CHECK-UNVERSIONED-LABEL: enum NewlyClosedEnum {
+// CHECK-UNVERSIONED-NEXT: };
+// CHECK-UNVERSIONED-LABEL: enum  __attribute__((enum_extensibility("closed"))) NewlyClosedEnum {
 // CHECK-UNVERSIONED-NEXT:     NewlyClosedEnumA = 1
-// CHECK-UNVERSIONED-NEXT: } __attribute__((enum_extensibility("closed")));
-// CHECK-UNVERSIONED-LABEL: enum ClosedToOpenEnum {
+// CHECK-UNVERSIONED-NEXT: };
+// CHECK-UNVERSIONED-LABEL: enum  __attribute__((enum_extensibility("open"))) ClosedToOpenEnum {
 // CHECK-UNVERSIONED-NEXT:     ClosedToOpenEnumA = 1
-// CHECK-UNVERSIONED-NEXT: } __attribute__((enum_extensibility("open")));
-// CHECK-UNVERSIONED-LABEL: enum OpenToClosedEnum {
+// CHECK-UNVERSIONED-NEXT: };
+// CHECK-UNVERSIONED-LABEL: enum  __attribute__((enum_extensibility("closed"))) OpenToClosedEnum {
 // CHECK-UNVERSIONED-NEXT:     OpenToClosedEnumA = 1
-// CHECK-UNVERSIONED-NEXT: } __attribute__((enum_extensibility("closed")));
-// CHECK-UNVERSIONED-LABEL: enum APINotedOpenEnum {
+// CHECK-UNVERSIONED-NEXT: };
+// CHECK-UNVERSIONED-LABEL: enum  __attribute__((enum_extensibility("open"))) APINotedOpenEnum {
 // CHECK-UNVERSIONED-NEXT:     APINotedOpenEnumA = 1
-// CHECK-UNVERSIONED-NEXT: } __attribute__((enum_extensibility("open")));
-// CHECK-UNVERSIONED-LABEL: enum APINotedClosedEnum {
+// CHECK-UNVERSIONED-NEXT: };
+// CHECK-UNVERSIONED-LABEL: enum  __attribute__((enum_extensibility("closed"))) APINotedClosedEnum {
 // CHECK-UNVERSIONED-NEXT:     APINotedClosedEnumA = 1
-// CHECK-UNVERSIONED-NEXT: } __attribute__((enum_extensibility("closed")));
+// CHECK-UNVERSIONED-NEXT: };
 
-// CHECK-VERSIONED-LABEL: enum FlagEnum {
+// CHECK-VERSIONED-LABEL: enum __attribute__((flag_enum)) FlagEnum {
 // CHECK-VERSIONED-NEXT:     FlagEnumA = 1,
 // CHECK-VERSIONED-NEXT:     FlagEnumB = 2
-// CHECK-VERSIONED-NEXT: } __attribute__((flag_enum));
+// CHECK-VERSIONED-NEXT: };
 // CHECK-VERSIONED-LABEL: enum NewlyFlagEnum {
 // CHECK-VERSIONED-NEXT:     NewlyFlagEnumA = 1,
 // CHECK-VERSIONED-NEXT:     NewlyFlagEnumB = 2
 // CHECK-VERSIONED-NEXT: };
-// CHECK-VERSIONED-LABEL: enum APINotedFlagEnum {
+// CHECK-VERSIONED-LABEL: enum __attribute__((flag_enum)) APINotedFlagEnum {
 // CHECK-VERSIONED-NEXT:     APINotedFlagEnumA = 1,
 // CHECK-VERSIONED-NEXT:     APINotedFlagEnumB = 2
-// CHECK-VERSIONED-NEXT: } __attribute__((flag_enum));
-// CHECK-VERSIONED-LABEL: enum OpenEnum {
+// CHECK-VERSIONED-NEXT: };
+// CHECK-VERSIONED-LABEL: enum __attribute__((enum_extensibility("open"))) OpenEnum {
 // CHECK-VERSIONED-NEXT:     OpenEnumA = 1
-// CHECK-VERSIONED-NEXT: } __attribute__((enum_extensibility("open")));
+// CHECK-VERSIONED-NEXT: };
 // CHECK-VERSIONED-LABEL: enum NewlyOpenEnum {
 // CHECK-VERSIONED-NEXT:     NewlyOpenEnumA = 1
 // CHECK-VERSIONED-NEXT: };
 // CHECK-VERSIONED-LABEL: enum NewlyClosedEnum {
 // CHECK-VERSIONED-NEXT:     NewlyClosedEnumA = 1
 // CHECK-VERSIONED-NEXT: };
-// CHECK-VERSIONED-LABEL: enum ClosedToOpenEnum {
+// CHECK-VERSIONED-LABEL: enum __attribute__((enum_extensibility("closed"))) ClosedToOpenEnum {
 // CHECK-VERSIONED-NEXT:     ClosedToOpenEnumA = 1
-// CHECK-VERSIONED-NEXT: } __attribute__((enum_extensibility("closed")));
-// CHECK-VERSIONED-LABEL: enum OpenToClosedEnum {
+// CHECK-VERSIONED-NEXT: };
+// CHECK-VERSIONED-LABEL: enum __attribute__((enum_extensibility("open"))) OpenToClosedEnum {
 // CHECK-VERSIONED-NEXT:     OpenToClosedEnumA = 1
-// CHECK-VERSIONED-NEXT: } __attribute__((enum_extensibility("open")));
-// CHECK-VERSIONED-LABEL: enum APINotedOpenEnum {
+// CHECK-VERSIONED-NEXT: };
+// CHECK-VERSIONED-LABEL: enum __attribute__((enum_extensibility("open"))) APINotedOpenEnum {
 // CHECK-VERSIONED-NEXT:     APINotedOpenEnumA = 1
-// CHECK-VERSIONED-NEXT: } __attribute__((enum_extensibility("open")));
-// CHECK-VERSIONED-LABEL: enum APINotedClosedEnum {
+// CHECK-VERSIONED-NEXT: };
+// CHECK-VERSIONED-LABEL: enum __attribute__((enum_extensibility("closed"))) APINotedClosedEnum {
 // CHECK-VERSIONED-NEXT:     APINotedClosedEnumA = 1
-// CHECK-VERSIONED-NEXT: } __attribute__((enum_extensibility("closed")));
+// CHECK-VERSIONED-NEXT: };
 
 // These don't actually have versioned information, so we just check them once.
-// CHECK-UNVERSIONED-LABEL: enum SoonToBeCFEnum {
+// CHECK-UNVERSIONED-LABEL: enum  __attribute__((enum_extensibility("open"))) SoonToBeCFEnum {
 // CHECK-UNVERSIONED-NEXT:     SoonToBeCFEnumA = 1
-// CHECK-UNVERSIONED-NEXT: } __attribute__((enum_extensibility("open")));
-// CHECK-UNVERSIONED-LABEL: enum SoonToBeNSEnum {
+// CHECK-UNVERSIONED-NEXT: };
+// CHECK-UNVERSIONED-LABEL: enum  __attribute__((enum_extensibility("open"))) SoonToBeNSEnum {
 // CHECK-UNVERSIONED-NEXT:     SoonToBeNSEnumA = 1
-// CHECK-UNVERSIONED-NEXT: } __attribute__((enum_extensibility("open")));
-// CHECK-UNVERSIONED-LABEL: enum SoonToBeCFOptions {
+// CHECK-UNVERSIONED-NEXT: };
+// CHECK-UNVERSIONED-LABEL: enum  __attribute__((enum_extensibility("open"))) __attribute__((flag_enum)) SoonToBeCFOptions {
 // CHECK-UNVERSIONED-NEXT:     SoonToBeCFOptionsA = 1
-// CHECK-UNVERSIONED-NEXT: } __attribute__((enum_extensibility("open"))) __attribute__((flag_enum));
-// CHECK-UNVERSIONED-LABEL: enum SoonToBeNSOptions {
+// CHECK-UNVERSIONED-NEXT: };
+// CHECK-UNVERSIONED-LABEL: enum  __attribute__((enum_extensibility("open"))) __attribute__((flag_enum)) SoonToBeNSOptions {
 // CHECK-UNVERSIONED-NEXT:     SoonToBeNSOptionsA = 1
-// CHECK-UNVERSIONED-NEXT: } __attribute__((enum_extensibility("open"))) __attribute__((flag_enum));
-// CHECK-UNVERSIONED-LABEL: enum SoonToBeCFClosedEnum {
+// CHECK-UNVERSIONED-NEXT: };
+// CHECK-UNVERSIONED-LABEL: enum  __attribute__((enum_extensibility("closed"))) SoonToBeCFClosedEnum {
 // CHECK-UNVERSIONED-NEXT:     SoonToBeCFClosedEnumA = 1
-// CHECK-UNVERSIONED-NEXT: } __attribute__((enum_extensibility("closed")));
-// CHECK-UNVERSIONED-LABEL: enum SoonToBeNSClosedEnum {
+// CHECK-UNVERSIONED-NEXT: };
+// CHECK-UNVERSIONED-LABEL: enum  __attribute__((enum_extensibility("closed"))) SoonToBeNSClosedEnum {
 // CHECK-UNVERSIONED-NEXT:     SoonToBeNSClosedEnumA = 1
-// CHECK-UNVERSIONED-NEXT: } __attribute__((enum_extensibility("closed")));
+// CHECK-UNVERSIONED-NEXT: };
 // CHECK-UNVERSIONED-LABEL: enum UndoAllThatHasBeenDoneToMe {
 // CHECK-UNVERSIONED-NEXT:     UndoAllThatHasBeenDoneToMeA = 1
 // CHECK-UNVERSIONED-NEXT: };


### PR DESCRIPTION
Cherry-pick of #189 to the 5.0 branch (though something got a little messed up in that PR, and it looks like an earlier version of that commit was already in upstream-with-swift). Reviewed by @DougGregor.