### PR TITLE
IndexStore: correct symbol visibility

### DIFF
--- a/include/indexstore/indexstore.h
+++ b/include/indexstore/indexstore.h
@@ -53,8 +53,12 @@
 #endif
 
 #ifndef INDEXSTORE_PUBLIC
-# if defined (_MSC_VER)
-#  define INDEXSTORE_PUBLIC __declspec(dllimport)
+# ifdef _WIN32
+#  ifdef IndexStore_EXPORTS
+#    define INDEXSTORE_PUBLIC __declspec(dllexport)
+#  else
+#    define INDEXSTORE_PUBLIC __declspec(dllimport)
+#  endif
 # else
 #  define INDEXSTORE_PUBLIC
 # endif

--- a/tools/IndexStore/CMakeLists.txt
+++ b/tools/IndexStore/CMakeLists.txt
@@ -12,9 +12,9 @@ set(LIBS
   clangIndexDataStore
 )
 
-set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/IndexStore.exports)
-
-set(ENABLE_SHARED SHARED)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
+  set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/IndexStore.exports)
+endif()
 
 if(WIN32)
   set(output_name "libIndexStore")
@@ -22,7 +22,7 @@ else()
   set(output_name "IndexStore")
 endif()
 
-add_clang_library(IndexStore ${ENABLE_SHARED} ${ENABLE_STATIC}
+add_clang_library(IndexStore SHARED
   OUTPUT_NAME ${output_name}
   ${SOURCES}
 
@@ -35,31 +35,19 @@ add_clang_library(IndexStore ${ENABLE_SHARED} ${ENABLE_STATIC}
   Support
   )
 
-set(INDEXSTORE_LIBRARY_VERSION "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
+if(APPLE)
+  set(INDEXSTORE_LIBRARY_VERSION "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
 
-if(ENABLE_SHARED)
-  if(WIN32)
-    set_target_properties(IndexStore
-      PROPERTIES
-      VERSION ${INDEXSTORE_LIBRARY_VERSION}
-      DEFINE_SYMBOL _CINDEX_LIB_)
-  elseif(APPLE)
-    set(INDEXSTORE_LINK_FLAGS " -Wl,-compatibility_version -Wl,1")
-    set(INDEXSTORE_LINK_FLAGS "${INDEXSTORE_LINK_FLAGS} -Wl,-current_version -Wl,${INDEXSTORE_LIBRARY_VERSION}")
+  set(INDEXSTORE_LINK_FLAGS " -Wl,-compatibility_version -Wl,1")
+  set(INDEXSTORE_LINK_FLAGS "${INDEXSTORE_LINK_FLAGS} -Wl,-current_version -Wl,${INDEXSTORE_LIBRARY_VERSION}")
 
-    check_include_files("CoreServices/CoreServices.h" HAVE_CORESERVICES_H)
-    if(HAVE_CORESERVICES_H)
-      set(INDEXSTORE_LINK_FLAGS "${INDEXSTORE_LINK_FLAGS} -framework CoreServices")
-    endif()
-
-    set_property(TARGET IndexStore APPEND_STRING PROPERTY
-                 LINK_FLAGS ${INDEXSTORE_LINK_FLAGS})
-  else()
-    set_target_properties(IndexStore
-      PROPERTIES
-      VERSION ${INDEXSTORE_LIBRARY_VERSION}
-      DEFINE_SYMBOL _CINDEX_LIB_)
+  check_include_files("CoreServices/CoreServices.h" HAVE_CORESERVICES_H)
+  if(HAVE_CORESERVICES_H)
+    set(INDEXSTORE_LINK_FLAGS "${INDEXSTORE_LINK_FLAGS} -framework CoreServices")
   endif()
+
+  set_property(TARGET IndexStore APPEND_STRING PROPERTY
+               LINK_FLAGS ${INDEXSTORE_LINK_FLAGS})
 endif()
 
 if (LLVM_INSTALL_TOOLCHAIN_ONLY)


### PR DESCRIPTION
On ELF targets, use protected visibility (symbols cannot be interpositioned).
On MachO, use default visibility.  On Windows, we need to define it to either
`__declspec(dllexport)` when building the library itself, or
`__declspec(dllimport)` when using the library.  This fixes a number of warnings
when building IndexCore for Windows.

Remove the use of the exports list and rely on the annotations instead.  This
makes the build similar across all the targets (Windows requires all listed
symbols to be present, and we would need to preprocess the list otherwise).

Fix the accidental usage of `_CINDEX_LIB_` opting for the CMake standard
variable `<Name>_EXPORTS`.

Simplify the logic in the CMake for Apple targets a bit.