### PR TITLE
AST: extend MS decoration handling for extended vectors

### DIFF
--- a/lib/AST/MicrosoftMangle.cpp
+++ b/lib/AST/MicrosoftMangle.cpp
@@ -2502,18 +2502,20 @@ void MicrosoftCXXNameMangler::mangleType(const VectorType *T, Qualifiers Quals,
   // Pattern match exactly the typedefs in our intrinsic headers.  Anything that
   // doesn't match the Intel types uses a custom mangling below.
   size_t OutSizeBefore = Out.tell();
-  llvm::Triple::ArchType AT =
-      getASTContext().getTargetInfo().getTriple().getArch();
-  if (AT == llvm::Triple::x86 || AT == llvm::Triple::x86_64) {
-    if (Width == 64 && ET->getKind() == BuiltinType::LongLong) {
-      mangleArtificalTagType(TTK_Union, "__m64");
-    } else if (Width >= 128) {
-      if (ET->getKind() == BuiltinType::Float)
-        mangleArtificalTagType(TTK_Union, "__m" + llvm::utostr(Width));
-      else if (ET->getKind() == BuiltinType::LongLong)
-        mangleArtificalTagType(TTK_Union, "__m" + llvm::utostr(Width) + 'i');
-      else if (ET->getKind() == BuiltinType::Double)
-        mangleArtificalTagType(TTK_Struct, "__m" + llvm::utostr(Width) + 'd');
+  if (!isa<ExtVectorType>(T)) {
+    llvm::Triple::ArchType AT =
+        getASTContext().getTargetInfo().getTriple().getArch();
+    if (AT == llvm::Triple::x86 || AT == llvm::Triple::x86_64) {
+      if (Width == 64 && ET->getKind() == BuiltinType::LongLong) {
+        mangleArtificalTagType(TTK_Union, "__m64");
+      } else if (Width >= 128) {
+        if (ET->getKind() == BuiltinType::Float)
+          mangleArtificalTagType(TTK_Union, "__m" + llvm::utostr(Width));
+        else if (ET->getKind() == BuiltinType::LongLong)
+          mangleArtificalTagType(TTK_Union, "__m" + llvm::utostr(Width) + 'i');
+        else if (ET->getKind() == BuiltinType::Double)
+          mangleArtificalTagType(TTK_Struct, "__m" + llvm::utostr(Width) + 'd');
+      }
     }
   }
 

--- a/test/CodeGenCXX/mangle-ms-vector-types.cpp
+++ b/test/CodeGenCXX/mangle-ms-vector-types.cpp
@@ -94,5 +94,9 @@ typedef __attribute__((ext_vector_type(4))) int vi4b;
 void foovi4b(vi4b) {}
 // CHECK: define dso_local void @"?foovi4b@@YAXT?$__vector@H$03@__clang@@@Z"
 
+typedef float __attribute__((__ext_vector_type__(3))) vf3;
+void foovf3(vf3) {}
+// CHECK: define dso_local void @"?foovf3@@YAXT?$__vector@M$02@__clang@@@Z"
+
 // Clang does not support vectors of complex types, so we can't test the
 // mangling of them.


### PR DESCRIPTION
We correctly handled extended vectors of non-floating point types.
However, we have the Intel style builtins which MSVC also supports which
do overlap in sizes with the floating point extended vectors.  This
would result in overloading of floating point extended vector types
which matched sizes (e.g. <3 x float> would be backed by a <4 x float>
and thus match sizes) to be mangled similarly.  Extended vectors are a
clang extension which live outside of the builtins, so mangle them all
similarly.  This change just extends the current scheme to treat
floating point types similar to the way that we treat other types
currently.

This now allows the swift runtime to be built for Windows again.

git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@345479 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 92a8170754dda7ca8769e784388396cc267fc68b)