### PR TITLE
Adjust for SVN r345637

### DIFF
--- a/lib/Tooling/Refactor/SymbolName.cpp
+++ b/lib/Tooling/Refactor/SymbolName.cpp
@@ -29,7 +29,7 @@ static void initNames(std::vector<std::string> &Strings, StringRef Name,
 }
 
 OldSymbolName::OldSymbolName(StringRef Name, const LangOptions &LangOpts) {
-  initNames(Strings, Name, LangOpts.ObjC1);
+  initNames(Strings, Name, LangOpts.ObjC);
 }
 
 OldSymbolName::OldSymbolName(StringRef Name, bool IsObjectiveCSelector) {

--- a/lib/Tooling/Refactor/TypeUtils.cpp
+++ b/lib/Tooling/Refactor/TypeUtils.cpp
@@ -50,7 +50,7 @@ static QualType preferredBoolType(const Decl *FunctionLikeParentDecl,
   case BuiltinType::Bool:
     // In Objective-C[++] we want to try to use 'BOOL' when the 'BOOL' typedef
     // is defined.
-    if (Ctx.getLangOpts().ObjC1 && Ctx.getBOOLDecl()) {
+    if (Ctx.getLangOpts().ObjC && Ctx.getBOOLDecl()) {
       if (Ctx.getLangOpts().CPlusPlus && FunctionLikeParentDecl) {
         // When extracting expression from a standalone function in
         // Objective-C++ we should use BOOL when expression uses BOOL, otherwise
@@ -183,7 +183,7 @@ QualType findExpressionLexicalType(const Decl *FunctionLikeParentDecl,
   }
 
   // The bool type adjustment is required only in C or Objective-C[++].
-  if (Ctx.getLangOpts().CPlusPlus && !Ctx.getLangOpts().ObjC1)
+  if (Ctx.getLangOpts().CPlusPlus && !Ctx.getLangOpts().ObjC)
     return T;
   E = E->IgnoreParenImpCasts();
   if (const auto *BinOp = dyn_cast<BinaryOperator>(E)) {

--- a/tools/clang-refactor-test/ClangRefactorTest.cpp
+++ b/tools/clang-refactor-test/ClangRefactorTest.cpp
@@ -594,7 +594,7 @@ int rename(CXTranslationUnit TU, CXIndex CIdx, ArrayRef<const char *> Args) {
 
     // FIXME: This is a hack
     LangOptions LangOpts;
-    LangOpts.ObjC1 = true;
+    LangOpts.ObjC = true;
     tooling::OldSymbolName NewSymbolName(opts::rename::NewName, LangOpts);
 
     if (ExpectedReplacements.empty()) {
@@ -729,7 +729,7 @@ int renameIndexedFile(CXIndex CIdx, ArrayRef<const char *> Args) {
     PrintFilenames = true;
 
   LangOptions LangOpts;
-  LangOpts.ObjC1 = true;
+  LangOpts.ObjC = true;
   tooling::OldSymbolName ExpectedReplacementStrings(
       opts::rename::IndexedNewNames[0], LangOpts);
 
@@ -750,7 +750,7 @@ int renameIndexedFile(CXIndex CIdx, ArrayRef<const char *> Args) {
                                             : SymbolIndex]
               .c_str();
       LangOptions LangOpts;
-      LangOpts.ObjC1 = true;
+      LangOpts.ObjC = true;
       tooling::OldSymbolName NewSymbolName(NewName, LangOpts);
 
       outs() << occurrenceToString(FileResult.Occurrences[I], /*IsLocal*/ false,


### PR DESCRIPTION
ObjC1 and ObjC2 were removed as ObjC1 has not been supported in a very
long time.  It has been replaced with `ObjC`.