### PR TITLE
Only warn on private API notes having the wrong case when appropriate

### DIFF
--- a/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/Headers/FrameworkWithActualPrivateModule.h
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/Headers/FrameworkWithActualPrivateModule.h
@@ -1,0 +1,1 @@
+extern int FrameworkWithActualPrivateModule;

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/Modules/module.modulemap
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module FrameworkWithActualPrivateModule {
+  umbrella header "FrameworkWithActualPrivateModule.h"
+  export *
+  module * { export * }
+}

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/Modules/module.private.modulemap
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/Modules/module.private.modulemap
@@ -1,0 +1,5 @@
+framework module FrameworkWithActualPrivateModule_Private {
+  umbrella header "FrameworkWithActualPrivateModule_Private.h"
+  export *
+  module * { export * }
+}

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/PrivateHeaders/FrameworkWithActualPrivateModule_Private.apinotes
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/PrivateHeaders/FrameworkWithActualPrivateModule_Private.apinotes
@@ -1,0 +1,1 @@
+Name: FrameworkWithActualPrivateModule_Private

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/PrivateHeaders/FrameworkWithActualPrivateModule_Private.h
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/PrivateHeaders/FrameworkWithActualPrivateModule_Private.h
@@ -1,0 +1,2 @@
+#include <FrameworkWithActualPrivateModule/FrameworkWithActualPrivateModule.h>
+extern int FrameworkWithActualPrivateModule_Private;

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCase.framework/Headers/FrameworkWithWrongCase.h
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCase.framework/Headers/FrameworkWithWrongCase.h
@@ -1,0 +1,1 @@
+extern int FrameworkWithWrongCase;

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCase.framework/Modules/module.modulemap
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCase.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module FrameworkWithWrongCase {
+  umbrella header "FrameworkWithWrongCase.h"
+  export *
+  module * { export * }
+}

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCase.framework/PrivateHeaders/FrameworkWithWrongCase_Private.apinotes
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCase.framework/PrivateHeaders/FrameworkWithWrongCase_Private.apinotes
@@ -1,0 +1,1 @@
+Name: FrameworkWithWrongCase

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCasePrivate.framework/Modules/module.private.modulemap
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCasePrivate.framework/Modules/module.private.modulemap
@@ -1,0 +1,1 @@
+module FrameworkWithWrongCasePrivate.Inner {}

--- a/test/APINotes/Inputs/Headers/ModuleWithWrongCase.h
+++ b/test/APINotes/Inputs/Headers/ModuleWithWrongCase.h
@@ -1,0 +1,1 @@
+extern int ModuleWithWrongCase;

--- a/test/APINotes/Inputs/Headers/ModuleWithWrongCasePrivate.h
+++ b/test/APINotes/Inputs/Headers/ModuleWithWrongCasePrivate.h
@@ -1,1 +1,1 @@
-extern int ModuleWithWrongCase;
+extern int ModuleWithWrongCasePrivate;

--- a/test/APINotes/Inputs/Headers/ModuleWithWrongCase_Private.apinotes
+++ b/test/APINotes/Inputs/Headers/ModuleWithWrongCase_Private.apinotes
@@ -1,0 +1,1 @@
+Name: ModuleWithWrongCasePrivate

--- a/test/APINotes/Inputs/Headers/module.modulemap
+++ b/test/APINotes/Inputs/Headers/module.modulemap
@@ -6,6 +6,10 @@ module BrokenTypes {
   header "BrokenTypes.h"
 }
 
+module ModuleWithWrongCase {
+  header "ModuleWithWrongCase.h"
+}
+
 module ModuleWithWrongCasePrivate {
   header "ModuleWithWrongCasePrivate.h"
 }

--- a/test/APINotes/Inputs/Headers/module.private.modulemap
+++ b/test/APINotes/Inputs/Headers/module.private.modulemap
@@ -1,3 +1,5 @@
 module PrivateLib {
   header "PrivateLib.h"
 }
+
+module ModuleWithWrongCasePrivate.Inner {}

--- a/test/APINotes/case-for-private-apinotes-file.c
+++ b/test/APINotes/case-for-private-apinotes-file.c
@@ -9,8 +9,14 @@
 // RUN: rm -rf %t
 // RUN: %clang_cc1 -fsyntax-only -fmodules -fapinotes-modules -fimplicit-module-maps -fmodules-cache-path=%t -iframework %S/Inputs/Frameworks -isystem %S/Inputs/Headers %s -Wnonportable-private-system-apinotes-path 2>&1 | FileCheck %s
 
+#include <ModuleWithWrongCase.h>
 #include <ModuleWithWrongCasePrivate.h>
+#include <FrameworkWithWrongCase/FrameworkWithWrongCase.h>
 #include <FrameworkWithWrongCasePrivate/FrameworkWithWrongCasePrivate.h>
+#include <FrameworkWithActualPrivateModule/FrameworkWithActualPrivateModule_Private.h>
 
+// CHECK-NOT: warning:
 // CHECK: warning: private API notes file for module 'ModuleWithWrongCasePrivate' should be named 'ModuleWithWrongCasePrivate_private.apinotes', not 'ModuleWithWrongCasePrivate_Private.apinotes'
+// CHECK-NOT: warning:
 // CHECK: warning: private API notes file for module 'FrameworkWithWrongCasePrivate' should be named 'FrameworkWithWrongCasePrivate_private.apinotes', not 'FrameworkWithWrongCasePrivate_Private.apinotes'
+// CHECK-NOT: warning:


### PR DESCRIPTION
Specifically, if the private API notes are for a top-level private module named "FooKit_Private", that's different from being for a public module named "FooKit". Don't warn in that case. (And rather than check for the presence of a "FooKit_Private", look at the submodules of "FooKit" and see if any of them come from a private module map.)

Fixes my own mistake from #190.

rdar://problem/45705724