### PR TITLE
tools: adjust for SVN r347141

### DIFF
--- a/tools/c-index-test/JSONAggregation.cpp
+++ b/tools/c-index-test/JSONAggregation.cpp
@@ -13,6 +13,7 @@
 #include "clang/Index/IndexDataStoreSymbolUtils.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/BuryPointer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 


### PR DESCRIPTION
BuryPointer has been moved into LLVM, adjust accordingly.