### PR TITLE
[Swift+WASM] Add an ABI hook for whether swiftcc is supported.

### DIFF
--- a/include/clang/CodeGen/SwiftCallingConv.h
+++ b/include/clang/CodeGen/SwiftCallingConv.h
@@ -178,6 +178,9 @@ void computeABIInfo(CodeGenModule &CGM, CGFunctionInfo &FI);
 /// Is swifterror lowered to a register by the target ABI?
 bool isSwiftErrorLoweredInRegister(CodeGenModule &CGM);
 
+/// Does that target ABI support the `swiftcc` calling convention?
+bool supportsSwiftCC(CodeGenModule &CGM);
+
 } // end namespace swiftcall
 } // end namespace CodeGen
 } // end namespace clang

--- a/lib/CodeGen/ABIInfo.h
+++ b/lib/CodeGen/ABIInfo.h
@@ -136,6 +136,10 @@ namespace swiftcall {
 
     virtual bool isSwiftErrorInRegister() const = 0;
 
+    virtual bool supportsSwiftCC() const {
+      return true;
+    }
+
     static bool classof(const ABIInfo *info) {
       return info->supportsSwift();
     }

--- a/lib/CodeGen/SwiftCallingConv.cpp
+++ b/lib/CodeGen/SwiftCallingConv.cpp
@@ -863,3 +863,7 @@ void swiftcall::computeABIInfo(CodeGenModule &CGM, CGFunctionInfo &FI) {
 bool swiftcall::isSwiftErrorLoweredInRegister(CodeGenModule &CGM) {
   return getSwiftABIInfo(CGM).isSwiftErrorInRegister();
 }
+
+bool swiftcall::supportsSwiftCC(CodeGenModule &CGM) {
+  return getSwiftABIInfo(CGM).supportsSwiftCC();
+}

--- a/lib/CodeGen/TargetInfo.cpp
+++ b/lib/CodeGen/TargetInfo.cpp
@@ -752,6 +752,10 @@ private:
   bool isSwiftErrorInRegister() const override {
     return false;
   }
+
+  bool supportsSwiftCC() const override {
+    return false;
+  }
 };
 
 class WebAssemblyTargetCodeGenInfo final : public TargetCodeGenInfo {


### PR DESCRIPTION
 - This adds an extension point so the ABI can declare whether or not it supports the swift calling convention. Open to suggestions if you think this doesn't belong here (or is flat out the wrong thing to try and to do bring up wasm).

 - [ ] Depends on #235.