### PR TITLE
Edit: adjust for SVN r347417

### DIFF
--- a/lib/Edit/FillInMissingSwitchEnumCases.cpp
+++ b/lib/Edit/FillInMissingSwitchEnumCases.cpp
@@ -86,13 +86,13 @@ void edit::fillInMissingSwitchEnumCases(
     }
     const auto *CS = cast<CaseStmt>(Case);
     if (const auto *LHS = CS->getLHS()) {
-      llvm::APSInt Value;
-      if (!LHS->EvaluateAsInt(Value, Context))
+      Expr::EvalResult Result;
+      if (!LHS->EvaluateAsInt(Result, Context))
         continue;
       // Only allow constant that fix into 64 bits.
-      if (Value.getMinSignedBits() > 64)
+      if (Result.Val.getInt().getMinSignedBits() > 64)
         continue;
-      CoveredEnumCases[Value.getSExtValue()] =
+      CoveredEnumCases[Result.Val.getInt().getSExtValue()] =
           CaseInfo{Case, NextCase, CaseIndex};
       // The cases in the switch are ordered back to front, so the last
       //  case is actually the first enum case in the switch.

--- a/lib/Tooling/Refactor/IfSwitchConversion.cpp
+++ b/lib/Tooling/Refactor/IfSwitchConversion.cpp
@@ -130,12 +130,12 @@ static bool isConditionValid(const Expr *E, ASTContext &Context,
     return false;
 
   // RHS must be a constant and unique.
-  llvm::APSInt Value;
-  if (!RHS->EvaluateAsInt(Value, Context))
+  Expr::EvalResult Result;
+  if (!RHS->EvaluateAsInt(Result, Context))
     return false;
   // Only allow constant that fix into 64 bits.
-  if (Value.getMinSignedBits() > 64 ||
-      !RHSValues.insert(Value.getExtValue()).second)
+  if (Result.Val.getInt().getMinSignedBits() > 64 ||
+      !RHSValues.insert(Result.Val.getInt().getExtValue()).second)
     return false;
 
   // LHS must be identical to the other LHS expressions.


### PR DESCRIPTION
`EvaluateAsInt` now returns an `EvalResult`.