### PR TITLE
[5.0] Only load private API notes if there are private submodules

### DIFF
--- a/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/Headers/FrameworkWithActualPrivateModule.h
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/Headers/FrameworkWithActualPrivateModule.h
@@ -1,0 +1,1 @@
+extern int FrameworkWithActualPrivateModule;

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/Modules/module.modulemap
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module FrameworkWithActualPrivateModule {
+  umbrella header "FrameworkWithActualPrivateModule.h"
+  export *
+  module * { export * }
+}

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/Modules/module.private.modulemap
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/Modules/module.private.modulemap
@@ -1,0 +1,5 @@
+framework module FrameworkWithActualPrivateModule_Private {
+  umbrella header "FrameworkWithActualPrivateModule_Private.h"
+  export *
+  module * { export * }
+}

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/PrivateHeaders/FrameworkWithActualPrivateModule_Private.apinotes
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/PrivateHeaders/FrameworkWithActualPrivateModule_Private.apinotes
@@ -1,0 +1,1 @@
+Name: FrameworkWithActualPrivateModule_Private

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/PrivateHeaders/FrameworkWithActualPrivateModule_Private.h
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithActualPrivateModule.framework/PrivateHeaders/FrameworkWithActualPrivateModule_Private.h
@@ -1,0 +1,2 @@
+#include <FrameworkWithActualPrivateModule/FrameworkWithActualPrivateModule.h>
+extern int FrameworkWithActualPrivateModule_Private;

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCase.framework/Headers/FrameworkWithWrongCase.h
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCase.framework/Headers/FrameworkWithWrongCase.h
@@ -1,0 +1,1 @@
+extern int FrameworkWithWrongCase;

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCase.framework/Modules/module.modulemap
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCase.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module FrameworkWithWrongCase {
+  umbrella header "FrameworkWithWrongCase.h"
+  export *
+  module * { export * }
+}

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCase.framework/PrivateHeaders/FrameworkWithWrongCase_Private.apinotes
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCase.framework/PrivateHeaders/FrameworkWithWrongCase_Private.apinotes
@@ -1,0 +1,1 @@
+Name: FrameworkWithWrongCase

--- a/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCasePrivate.framework/Modules/module.private.modulemap
+++ b/test/APINotes/Inputs/Frameworks/FrameworkWithWrongCasePrivate.framework/Modules/module.private.modulemap
@@ -1,0 +1,1 @@
+module FrameworkWithWrongCasePrivate.Inner {}

--- a/test/APINotes/Inputs/Headers/ModuleWithWrongCase.h
+++ b/test/APINotes/Inputs/Headers/ModuleWithWrongCase.h
@@ -1,0 +1,1 @@
+extern int ModuleWithWrongCase;

--- a/test/APINotes/Inputs/Headers/ModuleWithWrongCasePrivate.h
+++ b/test/APINotes/Inputs/Headers/ModuleWithWrongCasePrivate.h
@@ -1,1 +1,1 @@
-extern int ModuleWithWrongCase;
+extern int ModuleWithWrongCasePrivate;

--- a/test/APINotes/Inputs/Headers/ModuleWithWrongCase_Private.apinotes
+++ b/test/APINotes/Inputs/Headers/ModuleWithWrongCase_Private.apinotes
@@ -1,0 +1,1 @@
+Name: ModuleWithWrongCasePrivate

--- a/test/APINotes/Inputs/Headers/module.modulemap
+++ b/test/APINotes/Inputs/Headers/module.modulemap
@@ -6,6 +6,10 @@ module BrokenTypes {
   header "BrokenTypes.h"
 }
 
+module ModuleWithWrongCase {
+  header "ModuleWithWrongCase.h"
+}
+
 module ModuleWithWrongCasePrivate {
   header "ModuleWithWrongCasePrivate.h"
 }

--- a/test/APINotes/Inputs/Headers/module.private.modulemap
+++ b/test/APINotes/Inputs/Headers/module.private.modulemap
@@ -1,3 +1,5 @@
 module PrivateLib {
   header "PrivateLib.h"
 }
+
+module ModuleWithWrongCasePrivate.Inner {}

--- a/test/APINotes/case-for-private-apinotes-file.c
+++ b/test/APINotes/case-for-private-apinotes-file.c
@@ -9,8 +9,14 @@
 // RUN: rm -rf %t
 // RUN: %clang_cc1 -fsyntax-only -fmodules -fapinotes-modules -fimplicit-module-maps -fmodules-cache-path=%t -iframework %S/Inputs/Frameworks -isystem %S/Inputs/Headers %s -Wnonportable-private-system-apinotes-path 2>&1 | FileCheck %s
 
+#include <ModuleWithWrongCase.h>
 #include <ModuleWithWrongCasePrivate.h>
+#include <FrameworkWithWrongCase/FrameworkWithWrongCase.h>
 #include <FrameworkWithWrongCasePrivate/FrameworkWithWrongCasePrivate.h>
+#include <FrameworkWithActualPrivateModule/FrameworkWithActualPrivateModule_Private.h>
 
+// CHECK-NOT: warning:
 // CHECK: warning: private API notes file for module 'ModuleWithWrongCasePrivate' should be named 'ModuleWithWrongCasePrivate_private.apinotes', not 'ModuleWithWrongCasePrivate_Private.apinotes'
+// CHECK-NOT: warning:
 // CHECK: warning: private API notes file for module 'FrameworkWithWrongCasePrivate' should be named 'FrameworkWithWrongCasePrivate_private.apinotes', not 'FrameworkWithWrongCasePrivate_Private.apinotes'
+// CHECK-NOT: warning:


### PR DESCRIPTION
- **Explanation**: We're moving away from a convention of private submodules (MyKit.Private) to private top-level modules (MyKit_Private). Unfortunately, the name of a private API notes file (MyKit_private.apinotes) and an API notes files for a private top-level module (MyKit_Private.apinotes) are the same on a case-insensitive filesystem. Disambiguate by checking if MyKit has any private submodules.

- **Scope**: Affects frameworks (and non-framework libraries) with private top-level modules. Does not affect frameworks with private submodules, or no private module map at all.

- **Issue**: rdar://problem/45705724&46311788

- **Risk**: Low. Both the old and new configurations are accounted for here, and if anyone's mixing them we'll at least do something consistent.

- **Testing**: Passed regression tests.

- **Reviewed by**: @DougGregor 