### PR TITLE
[5.0] [APINotes] `RetainCountConvention: none` overrules `arc_cf_audited`

### DIFF
--- a/lib/Sema/SemaAPINotes.cpp
+++ b/lib/Sema/SemaAPINotes.cpp
@@ -215,7 +215,8 @@ static void handleAPINotedRetainCountAttribute(Sema &S, Decl *D,
       return isa<CFReturnsRetainedAttr>(next) ||
              isa<CFReturnsNotRetainedAttr>(next) ||
              isa<NSReturnsRetainedAttr>(next) ||
-             isa<NSReturnsNotRetainedAttr>(next);
+             isa<NSReturnsNotRetainedAttr>(next) ||
+             isa<CFAuditedTransferAttr>(next);
     });
   });
 }
@@ -227,8 +228,13 @@ static void handleAPINotedRetainCountConvention(
     return;
   switch (convention.getValue()) {
   case api_notes::RetainCountConventionKind::None:
-    handleAPINotedRetainCountAttribute(S, D, /*shouldAddAttribute*/false,
-                                       metadata);
+    if (isa<FunctionDecl>(D)) {
+      handleAPINotedRetainCountAttribute<CFUnknownTransferAttr>(
+          S, D, /*shouldAddAttribute*/true, metadata);
+    } else {
+      handleAPINotedRetainCountAttribute(S, D, /*shouldAddAttribute*/false,
+                                         metadata);
+    }
     break;
   case api_notes::RetainCountConventionKind::CFReturnsRetained:
     handleAPINotedRetainCountAttribute<CFReturnsRetainedAttr>(

--- a/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.apinotes
+++ b/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.apinotes
@@ -31,6 +31,12 @@ Functions:
   Parameters:
   - Position: 0
     RetainCountConvention: CFReturnsNotRetained
+- Name: getCFAuditedToUnowned_DUMP
+  RetainCountConvention: CFReturnsNotRetained
+- Name: getCFAuditedToOwned_DUMP
+  RetainCountConvention: CFReturnsRetained
+- Name: getCFAuditedToNone_DUMP
+  RetainCountConvention: none
 Classes:
 - Name: MethodTest
   Methods:

--- a/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.h
+++ b/test/APINotes/Inputs/Frameworks/SimpleKit.framework/Headers/SimpleKit.h
@@ -17,6 +17,12 @@ int indirectGetCFUnownedToOwned(void **out __attribute__((cf_returns_not_retaine
 int indirectGetCFOwnedToNone(void **out __attribute__((cf_returns_retained)));
 int indirectGetCFNoneToOwned(void **out);
 
+#pragma clang arc_cf_code_audited begin
+void *getCFAuditedToUnowned_DUMP(void);
+void *getCFAuditedToOwned_DUMP(void);
+void *getCFAuditedToNone_DUMP(void);
+#pragma clang arc_cf_code_audited end
+
 @interface MethodTest
 - (id)getOwnedToUnowned __attribute__((ns_returns_retained));
 - (id)getUnownedToOwned __attribute__((ns_returns_not_retained));

--- a/test/APINotes/retain-count-convention.m
+++ b/test/APINotes/retain-count-convention.m
@@ -1,12 +1,13 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules  -fdisable-module-hash -fsyntax-only -F %S/Inputs/Frameworks %s
 // RUN: %clang_cc1 -ast-print %t/ModulesCache/SimpleKit.pcm | FileCheck %s
+// RUN: %clang_cc1 -ast-dump -ast-dump-filter 'DUMP' %t/ModulesCache/SimpleKit.pcm | FileCheck -check-prefix CHECK-DUMP %s
 
 #import <SimpleKit/SimpleKit.h>
 
 // CHECK: void *getCFOwnedToUnowned() __attribute__((cf_returns_not_retained));
 // CHECK: void *getCFUnownedToOwned() __attribute__((cf_returns_retained));
-// CHECK: void *getCFOwnedToNone();
+// CHECK: void *getCFOwnedToNone() __attribute__((cf_unknown_transfer));
 // CHECK: id getObjCOwnedToUnowned() __attribute__((ns_returns_not_retained));
 // CHECK: id getObjCUnownedToOwned() __attribute__((ns_returns_retained));
 // CHECK: int indirectGetCFOwnedToUnowned(void * _Nullable *out __attribute__((cf_returns_not_retained)));
@@ -18,3 +19,20 @@
 // CHECK: - (id)getOwnedToUnowned __attribute__((ns_returns_not_retained));
 // CHECK: - (id)getUnownedToOwned __attribute__((ns_returns_retained));
 // CHECK: @end
+
+// CHECK-DUMP-LABEL: Dumping getCFAuditedToUnowned_DUMP:
+// CHECK-DUMP-NEXT: FunctionDecl
+// CHECK-DUMP-NEXT: CFReturnsNotRetainedAttr
+// CHECK-DUMP-NEXT: CFAuditedTransferAttr
+// CHECK-DUMP-NOT: Attr
+
+// CHECK-DUMP-LABEL: Dumping getCFAuditedToOwned_DUMP:
+// CHECK-DUMP-NEXT: FunctionDecl
+// CHECK-DUMP-NEXT: CFReturnsRetainedAttr
+// CHECK-DUMP-NEXT: CFAuditedTransferAttr
+// CHECK-DUMP-NOT: Attr
+
+// CHECK-DUMP-LABEL: Dumping getCFAuditedToNone_DUMP:
+// CHECK-DUMP-NEXT: FunctionDecl
+// CHECK-DUMP-NEXT: CFUnknownTransferAttr
+// CHECK-DUMP-NOT: Attr


### PR DESCRIPTION
- **Explanation**: The `RetainCountConvention: none` API note wasn't taking effect within `pragma clang arc_cf_code_audited begin`/`end` regions, because the pragma was applied separately. Counteract that by adding an opt-out attribute when `RetainCountConvention: none` is used.

- **Scope**: Affects this particular API note only, and the added attribute only makes a difference in `pragma clang arc_cf_code_audited begin`/`end` regions.

- **Issue**: rdar://problem/39619530

- **Risk**: Low

- **Testing**: Passed regression tests.

- **Reviewed by**: @DougGregor 