### PR TITLE
[analyzer] ObjCDealloc: Fix a crash when a class attempts to deallocate a class.

### DIFF
--- a/lib/StaticAnalyzer/Checkers/CheckObjCDealloc.cpp
+++ b/lib/StaticAnalyzer/Checkers/CheckObjCDealloc.cpp
@@ -715,6 +715,10 @@ bool ObjCDeallocChecker::diagnoseExtraRelease(SymbolRef ReleasedValue,
 bool ObjCDeallocChecker::diagnoseMistakenDealloc(SymbolRef DeallocedValue,
                                                  const ObjCMethodCall &M,
                                                  CheckerContext &C) const {
+  // TODO: Apart from unknown/undefined receivers, this may happen when
+  // dealloc is called as a class method. Should we warn?
+  if (!DeallocedValue)
+    return false;
 
   // Find the property backing the instance variable that M
   // is dealloc'ing.

--- a/test/Analysis/MissingDealloc.m
+++ b/test/Analysis/MissingDealloc.m
@@ -183,4 +183,17 @@ __attribute__((objc_root_class))
 @implementation NonNSObjectMissingDealloc
 @end
 
-// CHECK: 4 warnings generated.
+
+//===------------------------------------------------------------------------===
+// Don't crash on calls to dealloc as a class method.
+
+@interface DeallocingClass : NSObject {}
+@end
+@implementation DeallocingClass
+- (void)dealloc {
+  [DeallocingClass dealloc]; // FIXME: Should we warn on this specifically?
+}
+#if NON_ARC
+// expected-warning@-2{{method possibly missing a [super dealloc] call}}
+#endif
+@end


### PR DESCRIPTION
@devincoughlin: review request for CCC.

rdar://problem/46376777

---

The checker wasn't prepared to see the dealloc message sent to the class itself
rather than to an instance, as if it was +dealloc.

Additionally, it wasn't prepared for pure-unknown or undefined self values.
The new guard covers that as well, but it is annoying to test because
both kinds of values shouldn't really appear and we generally want to
get rid of all of them (by modeling unknown values with symbols and
by warning on use of undefined values before they are used).

The CHECK: directive for FileCheck at the end of the test looks useless,
so i removed it.

Differential Revision: https://reviews.llvm.org/D55680


git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@349228 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 2b29b6937bcb5f43b5572b70837a6374b43927c5)