### PR TITLE
[APINotes] Test that 'ResultType' preserves the 'instancetype' flag

### DIFF
--- a/test/APINotes/Inputs/Headers/InstancetypeModule.apinotes
+++ b/test/APINotes/Inputs/Headers/InstancetypeModule.apinotes
@@ -1,0 +1,10 @@
+Name: InstancetypeModule
+Classes:
+- Name: SomeBaseClass
+  Methods:
+  - Selector: instancetypeFactoryMethod
+    MethodKind: Class
+    ResultType: SomeBaseClass * _Nonnull
+  - Selector: staticFactoryMethod
+    MethodKind: Class
+    ResultType: SomeBaseClass * _Nonnull

--- a/test/APINotes/Inputs/Headers/InstancetypeModule.h
+++ b/test/APINotes/Inputs/Headers/InstancetypeModule.h
@@ -1,0 +1,10 @@
+@interface Object
+@end
+
+@interface SomeBaseClass : Object
++ (nullable instancetype)instancetypeFactoryMethod;
++ (nullable SomeBaseClass *)staticFactoryMethod;
+@end
+
+@interface SomeSubclass : SomeBaseClass
+@end

--- a/test/APINotes/Inputs/Headers/module.modulemap
+++ b/test/APINotes/Inputs/Headers/module.modulemap
@@ -2,6 +2,10 @@ module HeaderLib {
   header "HeaderLib.h"
 }
 
+module InstancetypeModule {
+  header "InstancetypeModule.h"
+}
+
 module BrokenTypes {
   header "BrokenTypes.h"
 }

--- a/test/APINotes/instancetype.m
+++ b/test/APINotes/instancetype.m
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules -fsyntax-only -I %S/Inputs/Headers -verify %s
+
+@import InstancetypeModule;
+
+void test() {
+  // The nullability is here to verify that the API notes were applied.
+  int good = [SomeSubclass instancetypeFactoryMethod]; // expected-warning {{initializing 'int' with an expression of type 'SomeSubclass * _Nonnull'}}
+  int bad = [SomeSubclass staticFactoryMethod]; // expected-warning {{initializing 'int' with an expression of type 'SomeBaseClass * _Nonnull'}}
+}


### PR DESCRIPTION
It probably shouldn't, but we now have Apple frameworks relying on this behavior, and since `instancetype` isn't a real type you can't specify it using `ResultType` anyway. In practice, if we had to be locked into some behavior for `instancetype`-returning methods, this is probably the best one.