### PR TITLE
[cl-compat] Change /JMC from unsupported to ignored.

### DIFF
--- a/include/clang/Driver/CLCompatOptions.td
+++ b/include/clang/Driver/CLCompatOptions.td
@@ -329,6 +329,7 @@ def _SLASH_FC : CLIgnoredFlag<"FC">;
 def _SLASH_Fd : CLIgnoredJoined<"Fd">;
 def _SLASH_FS : CLIgnoredFlag<"FS">;
 def _SLASH_GF : CLIgnoredFlag<"GF">;
+def _SLASH_JMC : CLIgnoredFlag<"JMC">;
 def _SLASH_kernel_ : CLIgnoredFlag<"kernel-">;
 def _SLASH_nologo : CLIgnoredFlag<"nologo">;
 def _SLASH_Og : CLIgnoredFlag<"Og">;


### PR DESCRIPTION
A tracking bug for actually implementing this in clang-cl is at
https://bugs.llvm.org/show_bug.cgi?id=39156.

Differential Revision: https://reviews.llvm.org/D52798

git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@343629 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit d70ec8974c5a7d79f9af2b4ccdca81b44129621d)