### PR TITLE
[CMake] Add missing deps found via LLVM's -DBUILD_SHARED_LIBS=TRUE

### DIFF
--- a/tools/IndexStore/CMakeLists.txt
+++ b/tools/IndexStore/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
   )
 
 set(LIBS
+  clangIndex
   clangIndexDataStore
 )
 

--- a/tools/libclang/CMakeLists.txt
+++ b/tools/libclang/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SOURCES
 
 set(LIBS
   clangAST
+  clangASTMatchers
   clangAPINotes
   clangBasic
   clangFrontend


### PR DESCRIPTION
Top-of-tree builds just fine with: -DBUILD_SHARED_LIBS=TRUE

Cherry-pick of: 8ef579dfc4d3a0f7550dbd944d3c6079c0f61b6d