### PR TITLE
[CMake] External compiler_rt tests require LLVMTestingSupport

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -58,12 +58,16 @@ if(LLVM_BUILD_EXTERNAL_COMPILER_RT AND EXISTS ${COMPILER_RT_SRC_ROOT}/)
     endif()
   endforeach()
 
+  set(compiler_rt_configure_deps)
   if(TARGET cxx-headers)
-    set(COMPILER_RT_LIBCXX_DEPENDENCY "cxx-headers")
+    list(APPEND compiler_rt_configure_deps "cxx-headers")
+  endif()
+  if(LLVM_INCLUDE_TESTS)
+    list(APPEND compiler_rt_configure_deps LLVMTestingSupport)
   endif()
 
   ExternalProject_Add(compiler-rt
-    DEPENDS llvm-config clang ${COMPILER_RT_LIBCXX_DEPENDENCY}
+    DEPENDS llvm-config clang ${compiler_rt_configure_deps}
     PREFIX ${COMPILER_RT_PREFIX}
     SOURCE_DIR ${COMPILER_RT_SRC_ROOT}
     STAMP_DIR ${STAMP_DIR}


### PR DESCRIPTION
This is an ordering issue: If existing, testingsupport must be linked before the external compiler-rt is configured. Once compiler-rt adopts the find_package() approach to pull in its dependencies, this will all get much easier/obsolete.

The current situation caused investigations to go in wrong directions repeatedly. If builds failed (for other reasons), Jenkins was reporting this as the cause:
```
llvm-config: error: component libraries and shared library

llvm-config: error: missing: /Users/buildnode/jenkins/workspace/oss-lldb-osx/Ninja-ReleaseAssert/llvm-macosx-x86_64/lib/libLLVMTestingSupport.a
  CMake Warning at cmake/Modules/CompilerRTUtils.cmake:263 (message):
llvm-config finding testingsupport failed with status 1
  Call Stack (most recent call first):
CMakeLists.txt:69 (load_llvm_config)
```