### PR TITLE
Update reference to tok::angle_string_literal

### DIFF
--- a/lib/Tooling/Refactor/RenameIndexedFile.cpp
+++ b/lib/Tooling/Refactor/RenameIndexedFile.cpp
@@ -417,7 +417,7 @@ static void findInclusionDirectiveOccurrence(
   RawLex.setParsingPreprocessorDirective(true);
   RawLex.LexIncludeFilename(RawTok);
   if (RawTok.isNot(tok::string_literal) &&
-      RawTok.isNot(tok::angle_string_literal))
+      RawTok.isNot(tok::header_name))
     return;
   StringRef Filename = llvm::sys::path::filename(
       StringRef(RawTok.getLiteralData(), RawTok.getLength())


### PR DESCRIPTION
Clang r356530 renamed tok::angle_string_literal to tok::header_name.
Update this code to match.