### PR TITLE
Refactor: adjust for SVN r356530

### DIFF
--- a/lib/Tooling/Refactor/RenameIndexedFile.cpp
+++ b/lib/Tooling/Refactor/RenameIndexedFile.cpp
@@ -416,8 +416,7 @@ static void findInclusionDirectiveOccurrence(
   // string literal/angled literal.
   RawLex.setParsingPreprocessorDirective(true);
   RawLex.LexIncludeFilename(RawTok);
-  if (RawTok.isNot(tok::string_literal) &&
-      RawTok.isNot(tok::angle_string_literal))
+  if (RawTok.isNot(tok::string_literal) && RawTok.isNot(tok::header_name))
     return;
   StringRef Filename = llvm::sys::path::filename(
       StringRef(RawTok.getLiteralData(), RawTok.getLength())


### PR DESCRIPTION
angle_string was renamed to header_name.  Adjust the Refactor library
accordingly.