### PR TITLE
[CodeGenObjC] Fix a nullptr dyn_cast

### DIFF
--- a/lib/CodeGen/CGObjC.cpp
+++ b/lib/CodeGen/CGObjC.cpp
@@ -444,8 +444,9 @@ tryEmitSpecializedAllocInit(CodeGenFunction &CGF, const ObjCMessageExpr *OME) {
 
   // Match the exact pattern '[[MyClass alloc] init]'.
   Selector Sel = OME->getSelector();
-  if (!OME->isInstanceMessage() || !OME->getType()->isObjCObjectPointerType() ||
-      !Sel.isUnarySelector() || Sel.getNameForSlot(0) != "init")
+  if (OME->getReceiverKind() != ObjCMessageExpr::Instance ||
+      !OME->getType()->isObjCObjectPointerType() || !Sel.isUnarySelector() ||
+      Sel.getNameForSlot(0) != "init")
     return None;
 
   // Okay, this is '[receiver init]', check if 'receiver' is '[cls alloc]'.

--- a/test/CodeGenObjC/objc-alloc-init.m
+++ b/test/CodeGenObjC/objc-alloc-init.m
@@ -26,3 +26,16 @@ void f() {
   // EITHER: call {{.*}} @objc_msgSend
 }
 @end
+
+// rdar://48247290
+@interface Base
+-(instancetype)init;
+@end
+
+@interface Derived : Base
+@end
+@implementation Derived
+-(void)meth {
+  [super init];
+}
+@end


### PR DESCRIPTION
ObjCMessageExpr::getInstanceReceiver returns nullptr if the receiver
is 'super'. Make this check more strict, since we don't care about
messages to super here.

rdar://48247290

git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@354826 91177308-0d34-0410-b5e6-96231b3b80d8