### PR TITLE
[IndexStore] Enable blocks support on Linux builds

### DIFF
--- a/tools/IndexStore/CMakeLists.txt
+++ b/tools/IndexStore/CMakeLists.txt
@@ -49,6 +49,10 @@ if(APPLE)
 
   set_property(TARGET IndexStore APPEND_STRING PROPERTY
                LINK_FLAGS ${INDEXSTORE_LINK_FLAGS})
+else()
+  # Blocks are off by default on non-darwin platforms.
+  target_compile_options(IndexStore PRIVATE -fblocks)
+  target_link_libraries(IndexStore PRIVATE BlocksRuntime)
 endif()
 
 if (LLVM_INSTALL_TOOLCHAIN_ONLY)


### PR DESCRIPTION
This enables block support for Linux builds of `IndexStore`. The motivation is to have the various `_apply` functions be present (ex `indexstore_store_units_apply`). Without this, only the function pointer variants are available (ex `indexstore_store_units_apply_f`).