### PR TITLE
Fixing swift-clang tests that fail due to missing PrintingPolicy init in ctor.

### DIFF
--- a/include/clang/AST/PrettyPrinter.h
+++ b/include/clang/AST/PrettyPrinter.h
@@ -38,6 +38,7 @@ struct PrintingPolicy {
   /// Create a default printing policy for the specified language.
   PrintingPolicy(const LangOptions &LO)
       : Indentation(2), SuppressSpecifiers(false),
+        SupressStorageClassSpecifiers(false),
         SuppressTagKeyword(LO.CPlusPlus), IncludeTagDefinition(false),
         SuppressScope(false), SuppressUnwrittenScope(false),
         SuppressInitializers(false), ConstantArraySizeAsWritten(false),


### PR DESCRIPTION

The following tests that were failing were:

    Clang :: OpenMP/for_simd_ast_print.cpp
    Clang :: OpenMP/simd_ast_print.cpp
    Clang-Unit :: AST/./ASTTests/DeclPrinter.TestFunctionDecl4
    Clang-Unit :: AST/./ASTTests/DeclPrinter.TestFunctionDecl5

They were failing because SupressStorageClassSpecifiers not being properly
initialized in PrintingPolicy in include/clang/AST/PrettyPrinter.h and when it
was used in lib/AST/DeclPrinter.cpp "static" was not being printed:

```
  if (!Policy.SuppressSpecifiers) {
    if (!Policy.SupressStorageClassSpecifiers) {
      switch (D->getStorageClass()) {
      case SC_None: break;
      case SC_Extern: Out << "extern "; break;
      case SC_Static: Out << "static "; break;
```

These tests pass in upstream clang because SupressStorageClassSpecifiers was
never pushed upstream.