### PR TITLE
Fixing SemaObjC tests that take -x objective-c++ with -stdlib=libc++

### DIFF
--- a/test/SemaObjC/class-stub-attr-unsupported.m
+++ b/test/SemaObjC/class-stub-attr-unsupported.m
@@ -1,5 +1,5 @@
 // RUN: %clang -target i386-apple-darwin -fsyntax-only -Xclang -verify %s
-// RUN: %clang -target i386-apple-darwin -x objective-c++ -fsyntax-only -Xclang -verify %s
+// RUN: %clang -target i386-apple-darwin -x objective-c++ -stdlib=libc++ -fsyntax-only -Xclang -verify %s
 
 @interface NSObject
 @end

--- a/test/SemaObjC/class-stub-attr.m
+++ b/test/SemaObjC/class-stub-attr.m
@@ -1,5 +1,5 @@
 // RUN: %clang -target x86_64-apple-darwin -fsyntax-only -Xclang -verify %s
-// RUN: %clang -target x86_64-apple-darwin -x objective-c++ -fsyntax-only -Xclang -verify %s
+// RUN: %clang -target x86_64-apple-darwin -x objective-c++ -stdlib=libc++ -fsyntax-only -Xclang -verify %s
 
 @interface NSObject
 @end


### PR DESCRIPTION
  The following get fixed with this change (on Linux anyways):

    Clang :: SemaObjC/class-stub-attr-unsupported.m
    Clang :: SemaObjC/class-stub-attr.m