### PR TITLE
Fixing clang-refactor-test tests on Linux by adding -fobjc-runtime=ios-5.0

### DIFF
--- a/test/Refactor/Extract/extract-capture-self.m
+++ b/test/Refactor/Extract/extract-capture-self.m
@@ -33,7 +33,7 @@
 // CHECK1: (AClass *object) {\nobject->ivar2 = 0;\n  object->ivar1 = 0;\n  object->ivar2 = 0;\n  object.prop = 0;\n  int x = object->ivar1;\n  int y = object.prop;\n  [object instanceMethod];\n  [AClass classMethod];\n}\n\n"
 // CHECK1: () {\nreturn [AClass classMethod];\n}\n\n"
 
-// RUN: clang-refactor-test perform -action extract -selected=%s:18:3-18:12 -selected=%s:20:3-20:18 -selected=%s:21:3-21:16 -selected=%s:23:3-23:20 -selected=%s:24:3-24:24 -selected=%s:18:3-25:23 -selected=%s:25:3-25:23 %s | FileCheck --check-prefix=CHECK1 %s
+// RUN: clang-refactor-test perform -action extract -selected=%s:18:3-18:12 -selected=%s:20:3-20:18 -selected=%s:21:3-21:16 -selected=%s:23:3-23:20 -selected=%s:24:3-24:24 -selected=%s:18:3-25:23 -selected=%s:25:3-25:23 %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK1 %s
 
 + (int)classMethod {
   int x = self.classMethod;
@@ -43,7 +43,7 @@
 // CHECK2: () {\nint x = AClass.classMethod;\n}
 // CHECK2: () {\nreturn [AClass classMethod];\n}
 
-// RUN: clang-refactor-test perform -action extract -selected=%s:39:3-39:27 -selected=%s:40:3-40:21 %s | FileCheck --check-prefix=CHECK2 %s
+// RUN: clang-refactor-test perform -action extract -selected=%s:39:3-39:27 -selected=%s:40:3-40:21 %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK2 %s
 
 - (void)rhsSelfCaptureAndRewrite:(AClass *)i { // CHECK3: "static void extracted(AClass *object, AClass *i) {\ni.prop= object.prop;\n}\n\n"
 // rhs-prop-begin: +1:3
@@ -51,6 +51,6 @@
 // rhs-prop-end: -1:21
 }
 
-// RUN: clang-refactor-test perform -action extract -selected=rhs-prop %s | FileCheck --check-prefix=CHECK3 %s
+// RUN: clang-refactor-test perform -action extract -selected=rhs-prop %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK3 %s
 
 @end

--- a/test/Refactor/Rename/ObjCClass.m
+++ b/test/Refactor/Rename/ObjCClass.m
@@ -4,9 +4,9 @@
 @interface I1 // CHECK1: rename [[@LINE]]:12 -> [[@LINE]]:14
 @end
 
-// RUN: clang-refactor-test rename-initiate -at=%s:1:8 -new-name=foo %s | FileCheck --check-prefix=CHECK1 %s
-// RUN: clang-refactor-test rename-initiate -at=%s:4:12 -new-name=foo %s | FileCheck --check-prefix=CHECK1 %s
-// RUN: clang-refactor-test rename-initiate -at=%s:2:8 -new-name=foo %s | FileCheck --check-prefix=CHECK2 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:1:8 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK1 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:4:12 -new-name=foo %s -fobjc-runtime=ios-5.0| FileCheck --check-prefix=CHECK1 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:2:8 -new-name=foo %s -fobjc-runtime=ios-5.0| FileCheck --check-prefix=CHECK2 %s
 
 @implementation I1 { // CHECK1: rename [[@LINE]]:17 -> [[@LINE]]:19
   I1 *interfaceIVar; // CHECK1: rename [[@LINE]]:3 -> [[@LINE]]:5
@@ -14,9 +14,9 @@
   int ivar; // CHECK3: rename [[@LINE]]:7 -> [[@LINE]]:11
 }
 
-// RUN: clang-refactor-test rename-initiate -at=%s:11:17 -new-name=foo %s | FileCheck --check-prefix=CHECK1 %s
-// RUN: clang-refactor-test rename-initiate -at=%s:12:3 -new-name=foo %s | FileCheck --check-prefix=CHECK1 %s
-// RUN: clang-refactor-test rename-initiate -at=%s:21:20 -new-name=foo %s | FileCheck --check-prefix=CHECK1 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:11:17 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK1 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:12:3 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK1 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:21:20 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK1 %s
 
 -(void)foo: (const I1 *)bar { // CHECK1: rename [[@LINE]]:20 -> [[@LINE]]:22
 
@@ -27,14 +27,14 @@
                            // CHECK3: rename [[@LINE-1]]:18 -> [[@LINE-1]]:22
 }
 
-// RUN: clang-refactor-test rename-initiate -at=%s:14:7 -new-name=foo %s | FileCheck --check-prefix=CHECK3 %s
-// RUN: clang-refactor-test rename-initiate -at=%s:23:3 -new-name=foo %s | FileCheck --check-prefix=CHECK3 %s
-// RUN: clang-refactor-test rename-initiate -at=%s:24:9 -new-name=foo %s | FileCheck --check-prefix=CHECK3 %s
-// RUN: clang-refactor-test rename-initiate -at=%s:25:14 -new-name=foo %s | FileCheck --check-prefix=CHECK3 %s
-// RUN: clang-refactor-test rename-initiate -at=%s:26:18 -new-name=foo %s | FileCheck --check-prefix=CHECK3 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:14:7 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK3 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:23:3 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK3 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:24:9 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK3 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:25:14 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK3 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:26:18 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK3 %s
 
-// RUN: clang-refactor-test rename-initiate -at=%s:12:7 -new-name=foo %s | FileCheck --check-prefix=CHECK4 %s
-// RUN: clang-refactor-test rename-initiate -at=%s:26:3 -new-name=foo %s | FileCheck --check-prefix=CHECK4 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:12:7 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK4 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:26:3 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK4 %s
 
 @end
 
@@ -44,11 +44,11 @@
 @implementation I1 (Category) // CHECK1: rename [[@LINE]]:17 -> [[@LINE]]:19
 @end                          // CHECK5: rename [[@LINE-1]]:21 -> [[@LINE-1]]:29
 
-// RUN: clang-refactor-test rename-initiate -at=%s:41:12 -new-name=foo %s | FileCheck --check-prefix=CHECK1 %s
-// RUN: clang-refactor-test rename-initiate -at=%s:44:17 -new-name=foo %s | FileCheck --check-prefix=CHECK1 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:41:12 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK1 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:44:17 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK1 %s
 
-// RUN: clang-refactor-test rename-initiate -at=%s:41:16 -new-name=foo %s | FileCheck --check-prefix=CHECK5 %s
-// RUN: clang-refactor-test rename-initiate -at=%s:44:21 -new-name=foo %s | FileCheck --check-prefix=CHECK5 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:41:16 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK5 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:44:21 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK5 %s
 
 // Implementation only-category:
 
@@ -58,10 +58,10 @@
 @implementation I3 (DummyCategory) // CHECK6: rename [[@LINE]]:17 -> [[@LINE]]:19
 @end                               // CHECK7: rename [[@LINE-1]]:21 -> [[@LINE-1]]:34
 
-// RUN: clang-refactor-test rename-initiate -at=%s:55:12 -new-name=foo %s | FileCheck --check-prefix=CHECK6 %s
-// RUN: clang-refactor-test rename-initiate -at=%s:58:17 -new-name=foo %s | FileCheck --check-prefix=CHECK6 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:55:12 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK6 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:58:17 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK6 %s
 
-// RUN: clang-refactor-test rename-initiate -at=%s:58:21 -new-name=foo %s | FileCheck --check-prefix=CHECK7 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:58:21 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK7 %s
 
 // Class extension:
 
@@ -71,8 +71,8 @@
 @implementation I3 // CHECK6: rename [[@LINE]]:17 -> [[@LINE]]:19
 @end
 
-// RUN: clang-refactor-test rename-initiate -at=%s:68:12 -new-name=foo %s | FileCheck --check-prefix=CHECK6 %s
-// RUN: clang-refactor-test rename-initiate -at=%s:71:17 -new-name=foo %s | FileCheck --check-prefix=CHECK6 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:68:12 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK6 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:71:17 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK6 %s
 
 // Ivar declared in the interface:
 
@@ -91,5 +91,5 @@
 
 @end
 
-// RUN: clang-refactor-test rename-initiate -at=%s:81:7 -new-name=foo %s | FileCheck --check-prefix=CHECK8 %s
-// RUN: clang-refactor-test rename-initiate -at=%s:89:3 -new-name=foo %s | FileCheck --check-prefix=CHECK8 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:81:7 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK8 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:89:3 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK8 %s

--- a/test/Refactor/Rename/ObjCImplementationTURequests.m
+++ b/test/Refactor/Rename/ObjCImplementationTURequests.m
@@ -6,10 +6,10 @@
 
 @end
 
-// RUN: clang-refactor-test rename-initiate -at=%s:2:7 -new-name=foo -implementation-tu="%S/Inputs/ObjCImplementationTURequestsImplementation.m" -dump-symbols %s | FileCheck --check-prefix=CHECK1 %s
+// RUN: clang-refactor-test rename-initiate -at=%s:2:7 -new-name=foo -implementation-tu="%S/Inputs/ObjCImplementationTURequestsImplementation.m" -dump-symbols %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK1 %s
 // CHECK1: Implementation TU USR: 'c:objc(cs)ExplicitIVarsInInterface@_requiresImplementationTU'
 
-// RUN: not clang-refactor-test rename-initiate -at=%s:2:7 -new-name=foo -implementation-tu="%S/MissingFile.m" -dump-symbols %s 2>&1 | FileCheck --check-prefix=CHECK-ERR1 %s
+// RUN: not clang-refactor-test rename-initiate -at=%s:2:7 -new-name=foo -implementation-tu="%S/MissingFile.m" -dump-symbols %s 2>&1 -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK-ERR1 %s
 // CHECK-ERR1: failed to load implementation TU
 
 @interface NoNeedForImplementationTUs {
@@ -27,6 +27,6 @@
 
 @end
 
-// RUN: clang-refactor-test rename-initiate -at=%s:16:7 -new-name=foo %s | FileCheck --check-prefix=CHECK-NO %s
-// RUN: clang-refactor-test rename-initiate -at=%s:25:7 -new-name=foo %s | FileCheck --check-prefix=CHECK-NO %s
+// RUN: clang-refactor-test rename-initiate -at=%s:16:7 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK-NO %s
+// RUN: clang-refactor-test rename-initiate -at=%s:25:7 -new-name=foo %s -fobjc-runtime=ios-5.0 | FileCheck --check-prefix=CHECK-NO %s
 // CHECK-NO-NOT: Implementation TU USR


### PR DESCRIPTION
On Linux, without -fobjc-runtime=ios-5.0 the following:

```
@implementation NoNeedForImplementationTUs {
  int _p2;
}
```

will get AST synthesized without:

```
`-ObjCPropertyImplDecl 0x7fad8c077070 <<invalid sloc>, line:21:15> <invalid sloc> p2 synthesize
  |-ObjCProperty 0x7fad8c069b68 'p2'
  `-ObjCIvar 0x7fad8c069a68 '_p2' 'int'
```

In this case, the refactoring wont find the decl in the @implementation.