### PR TITLE
[ASTImporter] Handle built-in when importing SourceLocation and FileID and dependent change

### DIFF
--- a/include/clang/AST/ASTImporter.h
+++ b/include/clang/AST/ASTImporter.h
@@ -329,9 +329,9 @@ class Attr;
     ///
     /// \returns The equivalent file ID in the source manager of the "to"
     /// context, or the import error.
-    llvm::Expected<FileID> Import_New(FileID);
+    llvm::Expected<FileID> Import_New(FileID, bool IsBuiltin = false);
     // FIXME: Remove this version.
-    FileID Import(FileID);
+    FileID Import(FileID, bool IsBuiltin = false);
 
     /// Import the given C++ constructor initializer from the "from"
     /// context into the "to" context.

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -8208,14 +8208,21 @@ FileID ASTImporter::Import(FileID FromID) {
       // than mmap the files several times.
       const FileEntry *Entry =
           ToFileManager.getFile(Cache->OrigEntry->getName());
-      if (!Entry)
-        return {};
-      ToID = ToSM.createFileID(Entry, ToIncludeLoc,
-                               FromSLoc.getFile().getFileCharacteristic());
-    } else {
+      // FIXME: The filename may be a virtual name that does probably not
+      // point to a valid file and we get no Entry here. In this case try with
+      // the memory buffer below.
+      if (Entry)
+        ToID = ToSM.createFileID(Entry, ToIncludeLoc,
+                                 FromSLoc.getFile().getFileCharacteristic());
+    }
+    if (ToID.isInvalid()) {
       // FIXME: We want to re-use the existing MemoryBuffer!
-      const llvm::MemoryBuffer *FromBuf =
-          Cache->getBuffer(FromContext.getDiagnostics(), FromSM);
+      bool Invalid = true;
+      const llvm::MemoryBuffer *FromBuf = Cache->getBuffer(
+          FromContext.getDiagnostics(), FromSM, SourceLocation{}, &Invalid);
+      if (!FromBuf || Invalid)
+        return {};
+
       std::unique_ptr<llvm::MemoryBuffer> ToBuf =
           llvm::MemoryBuffer::getMemBufferCopy(FromBuf->getBuffer(),
                                                FromBuf->getBufferIdentifier());
@@ -8223,6 +8230,8 @@ FileID ASTImporter::Import(FileID FromID) {
                                FromSLoc.getFile().getFileCharacteristic());
     }
   }
+
+  assert(ToID.isValid() && "Unexpected invalid fileID was created.");
 
   ImportedFileIDs[FromID] = ToID;
   return ToID;

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -8148,9 +8148,10 @@ SourceLocation ASTImporter::Import(SourceLocation FromLoc) {
     return {};
 
   SourceManager &FromSM = FromContext.getSourceManager();
+  bool IsBuiltin = FromSM.isWrittenInBuiltinFile(FromLoc);
 
   std::pair<FileID, unsigned> Decomposed = FromSM.getDecomposedLoc(FromLoc);
-  FileID ToFileID = Import(Decomposed.first);
+  FileID ToFileID = Import(Decomposed.first, IsBuiltin);
   if (ToFileID.isInvalid())
     return {};
   SourceManager &ToSM = ToContext.getSourceManager();
@@ -8165,13 +8166,13 @@ SourceRange ASTImporter::Import(SourceRange FromRange) {
   return SourceRange(Import(FromRange.getBegin()), Import(FromRange.getEnd()));
 }
 
-Expected<FileID> ASTImporter::Import_New(FileID FromID) {
-  FileID ToID = Import(FromID);
+Expected<FileID> ASTImporter::Import_New(FileID FromID, bool IsBuiltin) {
+  FileID ToID = Import(FromID, IsBuiltin);
   if (ToID.isInvalid() && FromID.isValid())
     return llvm::make_error<ImportError>();
   return ToID;
 }
-FileID ASTImporter::Import(FileID FromID) {
+FileID ASTImporter::Import(FileID FromID, bool IsBuiltin) {
   llvm::DenseMap<FileID, FileID>::iterator Pos = ImportedFileIDs.find(FromID);
   if (Pos != ImportedFileIDs.end())
     return Pos->second;
@@ -8197,25 +8198,29 @@ FileID ASTImporter::Import(FileID FromID) {
     }
     ToID = ToSM.getFileID(MLoc);
   } else {
-    // Include location of this file.
-    SourceLocation ToIncludeLoc = Import(FromSLoc.getFile().getIncludeLoc());
-
     const SrcMgr::ContentCache *Cache = FromSLoc.getFile().getContentCache();
-    if (Cache->OrigEntry && Cache->OrigEntry->getDir()) {
-      // FIXME: We probably want to use getVirtualFile(), so we don't hit the
-      // disk again
-      // FIXME: We definitely want to re-use the existing MemoryBuffer, rather
-      // than mmap the files several times.
-      const FileEntry *Entry =
-          ToFileManager.getFile(Cache->OrigEntry->getName());
-      // FIXME: The filename may be a virtual name that does probably not
-      // point to a valid file and we get no Entry here. In this case try with
-      // the memory buffer below.
-      if (Entry)
-        ToID = ToSM.createFileID(Entry, ToIncludeLoc,
-                                 FromSLoc.getFile().getFileCharacteristic());
+
+    if (!IsBuiltin) {
+      // Include location of this file.
+      SourceLocation ToIncludeLoc = Import(FromSLoc.getFile().getIncludeLoc());
+
+      if (Cache->OrigEntry && Cache->OrigEntry->getDir()) {
+        // FIXME: We probably want to use getVirtualFile(), so we don't hit the
+        // disk again
+        // FIXME: We definitely want to re-use the existing MemoryBuffer, rather
+        // than mmap the files several times.
+        const FileEntry *Entry =
+            ToFileManager.getFile(Cache->OrigEntry->getName());
+        // FIXME: The filename may be a virtual name that does probably not
+        // point to a valid file and we get no Entry here. In this case try with
+        // the memory buffer below.
+        if (Entry)
+          ToID = ToSM.createFileID(Entry, ToIncludeLoc,
+                                   FromSLoc.getFile().getFileCharacteristic());
+      }
     }
-    if (ToID.isInvalid()) {
+
+    if (ToID.isInvalid() || IsBuiltin) {
       // FIXME: We want to re-use the existing MemoryBuffer!
       bool Invalid = true;
       const llvm::MemoryBuffer *FromBuf = Cache->getBuffer(


### PR DESCRIPTION
Cherry-picking two commits the commits messages for each are below:

   [ASTImporter] Handle built-in when importing SourceLocation and FileID
    
    Summary:
    Currently when we see a built-in we try and import the include location. Instead what we do now is find the buffer like we do for the invalid case and copy that over to the to context.
    
    Differential Revision: https://reviews.llvm.org/D58743
    
    git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@355332 91177308-0d34-0410-b5e6-96231b3b80d8
    (cherry picked from commit 2f3e65f35906044e5f7dcd39bcd119e63db29fc7)

=======

    [ASTImporter] Improve import of FileID.
    
    Summary:
    Even if the content cache has a directory and filename, it may be a virtual file.
    The old code returned with error in this case, but it is worth to try to handle
    the file as it were a memory buffer.
    
    Reviewers: a.sidorin, shafik, martong, a_sidorin
    
    Reviewed By: shafik
    
    Subscribers: efriedma, rnkovacs, cfe-commits, dkrupp, martong, Szelethus, gamesh411
    
    Tags: #clang
    
    Differential Revision: https://reviews.llvm.org/D57590
    
    git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@355000 91177308-0d34-0410-b5e6-96231b3b80d8
    (cherry picked from commit 128411fb1722b87a4bea45913b42dc511d9c1b5d)
