### PR TITLE
[ASTImporter] Call to HandleNameConflict in VisitEnumDecl mistakeningly using Name instead of SearchName

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2506,7 +2506,7 @@ ExpectedDecl ASTNodeImporter::VisitEnumDecl(EnumDecl *D) {
     }
 
     if (!ConflictingDecls.empty()) {
-      Name = Importer.HandleNameConflict(Name, DC, IDNS,
+      Name = Importer.HandleNameConflict(SearchName, DC, IDNS,
                                          ConflictingDecls.data(),
                                          ConflictingDecls.size());
       if (!Name)


### PR DESCRIPTION
Summary:
https://reviews.llvm.org/D51633 added error handling to the ASTNodeImporter::VisitEnumDecl(...) for the conflicting names case. This could lead to erroneous return of an error in that case since we should have been using SearchName. Name may be empty in the case where we find the name via getTypedefNameForAnonDecl(...).

Differential Revision: https://reviews.llvm.org/D59665

git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@357940 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit a214a7f7b276ea66fea7d427868b6b4a9b13ac53)