### PR TITLE
Revert "[Modules] Make header inclusion order from umbrella dirs deterministic"

### DIFF
--- a/lib/Frontend/FrontendAction.cpp
+++ b/lib/Frontend/FrontendAction.cpp
@@ -344,7 +344,6 @@ static std::error_code collectModuleHeaderIncludes(
     llvm::sys::path::native(UmbrellaDir.Entry->getName(), DirNative);
 
     llvm::vfs::FileSystem &FS = *FileMgr.getVirtualFileSystem();
-    SmallVector<std::pair<std::string, const FileEntry *>, 8> Headers;
     for (llvm::vfs::recursive_directory_iterator Dir(FS, DirNative, EC), End;
          Dir != End && !EC; Dir.increment(EC)) {
       // Check whether this entry has an extension typically associated with
@@ -375,20 +374,13 @@ static std::error_code collectModuleHeaderIncludes(
            ++It)
         llvm::sys::path::append(RelativeHeader, *It);
 
-      Headers.push_back(std::make_pair(RelativeHeader.str(), Header));
+      // Include this header as part of the umbrella directory.
+      Module->addTopHeader(Header);
+      addHeaderInclude(RelativeHeader, Includes, LangOpts, Module->IsExternC);
     }
 
     if (EC)
       return EC;
-
-    // Sort header paths and make the header inclusion order deterministic
-    // across different OSs and filesystems.
-    llvm::array_pod_sort(Headers.begin(), Headers.end());
-    for (auto &H : Headers) {
-      // Include this header as part of the umbrella directory.
-      Module->addTopHeader(H.second);
-      addHeaderInclude(H.first, Includes, LangOpts, Module->IsExternC);
-    }
   }
 
   // Recurse into submodules.


### PR DESCRIPTION
Reverts apple/swift-clang#304. It's causing problems on CI still.