### PR TITLE
[ASTImporter] Copy Argument Passing Restrictions setting when importing a CXXRecordDecl definition

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -1798,6 +1798,9 @@ Error ASTNodeImporter::ImportDefinition(
     ToData.HasDeclaredCopyAssignmentWithConstParam
       = FromData.HasDeclaredCopyAssignmentWithConstParam;
 
+    // Copy over the data stored in RecordDeclBits
+    ToCXX->setArgPassingRestrictions(FromCXX->getArgPassingRestrictions());
+
     SmallVector<CXXBaseSpecifier *, 4> Bases;
     for (const auto &Base1 : FromCXX->bases()) {
       ExpectedType TyOrErr = import(Base1.getType());

--- a/test/Import/cxx-record-flags/Inputs/F.cpp
+++ b/test/Import/cxx-record-flags/Inputs/F.cpp
@@ -1,0 +1,9 @@
+class FTrivial {
+  int i;
+};
+
+struct FNonTrivial {
+  virtual ~FNonTrivial() = default;
+  int i;
+};
+

--- a/test/Import/cxx-record-flags/test.cpp
+++ b/test/Import/cxx-record-flags/test.cpp
@@ -1,0 +1,14 @@
+// RUN: clang-import-test -dump-ast -import %S/Inputs/F.cpp -expression %s | FileCheck %s
+
+// CHECK: FTrivial
+// CHECK: DefinitionData
+// CHECK-SAME: pass_in_registers
+
+// CHECK: FNonTrivial
+// CHECK-NOT: pass_in_registers
+// CHECK: DefaultConstructor
+
+void expr() {
+  FTrivial f1;
+  FNonTrivial f2;
+}


### PR DESCRIPTION
Summary:
For a CXXRecordDecl the RecordDeclBits are stored in the DeclContext. Currently when we import the definition of a CXXRecordDecl via the ASTImporter we do not copy over this data.
This change will add support for copying the ArgPassingRestrictions from RecordDeclBits to fix an LLDB expression parsing bug where we would set it to not pass in registers.
Note, we did not copy over any other of the RecordDeclBits since we don't have tests for those. We know that copying over LoadedFieldsFromExternalStorage would be a error and that may be the case for others as well.

The companion LLDB review: https://reviews.llvm.org/D61146

Differential Review: https://reviews.llvm.org/D61140

git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@359338 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit f894ac01dc3f4a29fa6fbaf44518c5de98c848b4)