### PR TITLE
[Test] Make `ninja check-clang` work on Linux

### DIFF
--- a/test/Parser/pragma-attribute-context.cpp
+++ b/test/Parser/pragma-attribute-context.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -verify -std=c++11 %s
-// RUN: %clang_cc1 -xobjective-c++ -verify -std=c++11 %s
+// RUN: %clang_cc1 -triple x86_64-apple-darwin9.0.0 -verify -std=c++11 %s
+// RUN: %clang_cc1 -triple x86_64-apple-darwin9.0.0 -xobjective-c++ -verify -std=c++11 %s
 
 #if !__has_extension(pragma_clang_attribute_external_declaration)
 #error


### PR DESCRIPTION
Hi @bob-wilson – Can we merge this fix? It'll make `ninja check-clang` pass on my Linux box. Thanks!