### PR TITLE
[IndexDataStore] Sort unit names using std::sort()

### DIFF
--- a/lib/IndexDataStore/IndexDataStore.cpp
+++ b/lib/IndexDataStore/IndexDataStore.cpp
@@ -85,7 +85,7 @@ bool IndexDataStoreImpl::foreachUnitName(bool sorted,
   }
 
   if (sorted) {
-    llvm::array_pod_sort(filenames.begin(), filenames.end());
+    std::sort(filenames.begin(), filenames.end());
     for (auto &fname : filenames)
       if (!receiver(fname))
         return false;


### PR DESCRIPTION
std::string is not POD.