### PR TITLE
WIP: [Swift+WASM] patches to support compiling Swift to WebAssembly

### DIFF
--- a/lib/Basic/Targets/WebAssembly.cpp
+++ b/lib/Basic/Targets/WebAssembly.cpp
@@ -60,6 +60,8 @@ void WebAssemblyTargetInfo::fillValidCPUList(
 void WebAssemblyTargetInfo::getTargetDefines(const LangOptions &Opts,
                                              MacroBuilder &Builder) const {
   defineCPUMacros(Builder, "wasm", /*Tuning=*/false);
+  // HACK: too lazy to backport the -emscripten target here
+  Builder.defineMacro("__EMSCRIPTEN__");
   if (SIMDLevel >= SIMD128)
     Builder.defineMacro("__wasm_simd128__");
   if (SIMDLevel >= UnimplementedSIMD128)

--- a/lib/Basic/Targets/WebAssembly.cpp
+++ b/lib/Basic/Targets/WebAssembly.cpp
@@ -60,8 +60,10 @@ void WebAssemblyTargetInfo::fillValidCPUList(
 void WebAssemblyTargetInfo::getTargetDefines(const LangOptions &Opts,
                                              MacroBuilder &Builder) const {
   defineCPUMacros(Builder, "wasm", /*Tuning=*/false);
-  // HACK: too lazy to backport the -emscripten target here
-  Builder.defineMacro("__EMSCRIPTEN__");
+  // HACK: too lazy to backport the WASI target here
+  Builder.defineMacro("__wasi__");
+  // HACK: globally enable WASI mmap emulation
+  Builder.defineMacro("_WASI_EMULATED_MMAN");
   if (SIMDLevel >= SIMD128)
     Builder.defineMacro("__wasm_simd128__");
   if (SIMDLevel >= UnimplementedSIMD128)

--- a/lib/Basic/Targets/WebAssembly.h
+++ b/lib/Basic/Targets/WebAssembly.h
@@ -114,6 +114,16 @@ private:
                ? (IsSigned ? SignedLongLong : UnsignedLongLong)
                : TargetInfo::getLeastIntTypeByWidth(BitWidth, IsSigned);
   }
+
+  CallingConvCheckResult checkCallingConvention(CallingConv CC) const override {
+    switch (CC) {
+    case CC_C:
+    case CC_Swift:
+      return CCCR_OK;
+    default:
+      return CCCR_Warning;
+    }
+  }
 };
 class LLVM_LIBRARY_VISIBILITY WebAssembly32TargetInfo
     : public WebAssemblyTargetInfo {

--- a/lib/Driver/ToolChains/Clang.cpp
+++ b/lib/Driver/ToolChains/Clang.cpp
@@ -448,6 +448,9 @@ static void addExceptionArgs(const ArgList &Args, types::ID InputType,
     // Disable C++ EH by default on XCore and PS4.
     bool CXXExceptionsEnabled =
         Triple.getArch() != llvm::Triple::xcore && !Triple.isPS4CPU();
+    // WebAssembly: no exception handling on WASI
+    if (Triple.isOSBinFormatWasm())
+      CXXExceptionsEnabled = false;
     Arg *ExceptionArg = Args.getLastArg(
         options::OPT_fcxx_exceptions, options::OPT_fno_cxx_exceptions,
         options::OPT_fexceptions, options::OPT_fno_exceptions);


### PR DESCRIPTION
These are the Clang changes required to cross-compile Swift programs to WebAssembly.

List of changes:

- enable Swift calling convention for WebAssembly
- disable exceptions by default on WebAssembly, as WASI doesn't support it
- enable the requisite wasi define manually, since swift-llvm is too old to support the WASI triple

See https://github.com/apple/swift/pull/24684 for more information.

We're planning to upstream the first patch to upstream LLVM; the other two patches won't be needed when Swift updates its llvm/clang.