### PR TITLE
Update for Lexer API Changes

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7117,7 +7117,7 @@ TypeResult Parser::parseTypeFromString(StringRef typeStr, StringRef context,
   tokens.push_back(Tok);
 
   // Enter the tokens into the token stream.
-  PP.EnterTokenStream(tokens, /*DisableMacroExpansion=*/false);
+  PP.EnterTokenStream(tokens, /*DisableMacroExpansion=*/false, /*IsReinject=*/false);
 
   // Consume the current token so that we'll start parsing the tokens we
   // added to the stream.


### PR DESCRIPTION
EnterTokenStream now requires an additional argument, update the usages.

See also: git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@361007
91177308-0d34-0410-b5e6-96231b3b80d8

See also: https://github.com/apple/swift-clang/commit/a3c314617033ec86c5a4eac093e301b359c48c9d