### PR TITLE
[5.0] Provide a custom entry for specifying module cache paths

### DIFF
--- a/lib/Driver/ToolChains/Clang.cpp
+++ b/lib/Driver/ToolChains/Clang.cpp
@@ -2518,6 +2518,11 @@ static void RenderBuiltinOptions(const ToolChain &TC, const llvm::Triple &T,
 }
 
 void Driver::getDefaultModuleCachePath(SmallVectorImpl<char> &Result) {
+  if (const char *ModuleCacheStrDir = ::getenv("CUSTOM_CLANG_MODULE_CACHE")) {
+    Result.append(ModuleCacheStrDir,
+                  ModuleCacheStrDir + strlen(ModuleCacheStrDir));
+    return;
+  }
   llvm::sys::path::system_temp_directory(/*erasedOnReboot=*/false, Result);
   llvm::sys::path::append(Result, "org.llvm.clang.");
   appendUserToPath(Result);


### PR DESCRIPTION
This is really handy for use in bots with multiple competing workspaces, for
builds that do not provide an explicit module cache. This is controlled
by the CUSTOM_CLANG_MODULE_CACHE env variable.

export CUSTOM_CLANG_MODULE_CACHE="/tmp/yoyo"
$ echo "int foo()" | clang -x objective-c -fmodules -\#\#\# - 2>&1 | tr " " "\n" | grep "\-cache"
"-fmodules-cache-path=/tmp/yoyo"

rdar://problem/48443680
(cherry picked from commit 099ed9c8ba6391f0af753c6393e78b37ceec27b3)