### PR TITLE
[ASTImporter] Call to HandleNameConflict in VisitRecordDecl mistakeningly using Name instead of SearchName

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2660,7 +2660,7 @@ ExpectedDecl ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
     } // for
 
     if (!ConflictingDecls.empty() && SearchName) {
-      Name = Importer.HandleNameConflict(Name, DC, IDNS,
+      Name = Importer.HandleNameConflict(SearchName, DC, IDNS,
                                          ConflictingDecls.data(),
                                          ConflictingDecls.size());
       if (!Name)


### PR DESCRIPTION
Summary:
https://reviews.llvm.org/D51633 added error handling to the ASTNodeImporter::VisitRecordDecl for the conflicting names case. This could lead to erroneous return of an error in that case since we should have been using SearchName. Name may be empty in the case where we find the name via D->getTypedefNameForAnonDecl()->getDeclName().

This fix is very similar to https://reviews.llvm.org/D59665

Differential Revision: https://reviews.llvm.org/D62352

git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@361650 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 424619da5abb9750e772e8ea8e15e9548c47d08c)