### PR TITLE
[Frontend] Respect SkipUnusedModuleMaps in DependencyCollector

### DIFF
--- a/include/clang/Frontend/Utils.h
+++ b/include/clang/Frontend/Utils.h
@@ -84,7 +84,8 @@ class DependencyCollector {
 public:
   virtual ~DependencyCollector();
 
-  virtual void attachToPreprocessor(Preprocessor &PP);
+  virtual void attachToPreprocessor(Preprocessor &PP,
+                                    const DependencyOutputOptions &Opts);
   virtual void attachToASTReader(ASTReader &R);
   ArrayRef<std::string> getDependencies() const { return Dependencies; }
 
@@ -153,7 +154,8 @@ public:
     VFSWriter.addFileMapping(VPath, RPath);
   }
 
-  void attachToPreprocessor(Preprocessor &PP) override;
+  void attachToPreprocessor(Preprocessor &PP,
+                            const DependencyOutputOptions &Opts) override;
   void attachToASTReader(ASTReader &R) override;
 
   virtual void writeFileMap();

--- a/lib/Frontend/CompilerInstance.cpp
+++ b/lib/Frontend/CompilerInstance.cpp
@@ -443,7 +443,7 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
   }
 
   for (auto &Listener : DependencyCollectors)
-    Listener->attachToPreprocessor(*PP);
+    Listener->attachToPreprocessor(*PP, DepOpts);
 
   // Handle generating header include information, if requested.
   if (DepOpts.ShowHeaderIncludes)

--- a/lib/Frontend/ModuleDependencyCollector.cpp
+++ b/lib/Frontend/ModuleDependencyCollector.cpp
@@ -121,7 +121,8 @@ void ModuleDependencyCollector::attachToASTReader(ASTReader &R) {
   R.addListener(llvm::make_unique<ModuleDependencyListener>(*this));
 }
 
-void ModuleDependencyCollector::attachToPreprocessor(Preprocessor &PP) {
+void ModuleDependencyCollector::attachToPreprocessor(
+    Preprocessor &PP, const DependencyOutputOptions &Opts) {
   PP.addPPCallbacks(llvm::make_unique<ModuleDependencyPPCallbacks>(
       *this, PP.getSourceManager()));
   PP.getHeaderSearchInfo().getModuleMap().addModuleMapCallbacks(

--- a/lib/Index/IndexingAction.cpp
+++ b/lib/Index/IndexingAction.cpp
@@ -433,8 +433,9 @@ public:
                                       RecordingOptions recordOpts)
       : IndexCtx(indexCtx), RecordOpts(recordOpts) {}
 
-  virtual void attachToPreprocessor(Preprocessor &PP) override {
-    DependencyCollector::attachToPreprocessor(PP);
+  virtual void attachToPreprocessor(
+      Preprocessor &PP, const DependencyOutputOptions &Opts) override {
+    DependencyCollector::attachToPreprocessor(PP, Opts);
     PP.addPPCallbacks(llvm::make_unique<IncludePPCallbacks>(
         IndexCtx, RecordOpts, Includes, PP.getSourceManager()));
   }
@@ -538,7 +539,7 @@ protected:
     Preprocessor &PP = CI.getPreprocessor();
     DepCollector.setSourceManager(&CI.getSourceManager());
     DepCollector.setSysrootPath(IndexCtx->getSysrootPath());
-    DepCollector.attachToPreprocessor(PP);
+    DepCollector.attachToPreprocessor(PP, CI.getDependencyOutputOpts());
 
     return llvm::make_unique<IndexASTConsumer>(CI.getPreprocessorPtr(),
                                                IndexCtx);


### PR DESCRIPTION
Previously, if SkipUnusedModuleMaps was passed, the DependencyCollector
would still add unused module maps as a dependency. Instead, it should
either add everything or only add those which are actually loaded.

rdar://51713745