### PR TITLE
[AST] Fix test for Swift clang

### DIFF
--- a/test/AST/ast-dump-decl-json.m
+++ b/test/AST/ast-dump-decl-json.m
@@ -933,11 +933,10 @@ void f() {
 
 // CHECK:  "kind": "ObjCCompatibleAliasDecl", 
 // CHECK-NEXT:  "loc": {
-// CHECK-NEXT:   "col": 22, 
 // CHECK-NEXT:   "file": "{{.*}}", 
 // CHECK-NEXT:   "line": 60, 
-// CHECK-NEXT:   "col": 1, 
-// CHECK-NEXT:   "tokLen": 1
+// CHECK-NEXT:   "col": 22, 
+// CHECK-NEXT:   "tokLen": 27
 // CHECK-NEXT:  }, 
 // CHECK-NEXT:  "range": {
 // CHECK-NEXT:   "begin": {


### PR DESCRIPTION
9890adfbee8f854732d0093bc8b2a32be1be8844 changed the AST for
ObjCCompatibleAliasDecl to record the alias name as its column location
rather than the @compatibility_alias. Update a newly added AST dumping
test accordingly.