### PR TITLE
[DependencyCollector] Add optional reproducer callback

### DIFF
--- a/include/clang/Frontend/Utils.h
+++ b/include/clang/Frontend/Utils.h
@@ -101,6 +101,10 @@ public:
   /// Return true if system files should be passed to sawDependency().
   virtual bool needSystemDependencies() { return false; }
 
+  void registerCallback(std::function<void(StringRef)> C) {
+    Callback = C;
+  }
+
   // implementation detail
   /// Add a dependency \p Filename if it has not been seen before and
   /// sawDependency() returns true.
@@ -110,6 +114,7 @@ public:
 private:
   llvm::StringSet<> Seen;
   std::vector<std::string> Dependencies;
+  std::function<void(StringRef)> Callback;
 };
 
 /// Builds a depdenency file when attached to a Preprocessor (for includes) and

--- a/lib/Frontend/DependencyFile.cpp
+++ b/lib/Frontend/DependencyFile.cpp
@@ -119,8 +119,11 @@ void DependencyCollector::maybeAddDependency(StringRef Filename, bool FromModule
                                             bool IsSystem, bool IsModuleFile,
                                             bool IsMissing) {
   if (Seen.insert(Filename).second &&
-      sawDependency(Filename, FromModule, IsSystem, IsModuleFile, IsMissing))
+      sawDependency(Filename, FromModule, IsSystem, IsModuleFile, IsMissing)) {
     Dependencies.push_back(Filename);
+    if (Callback)
+      Callback(Filename);
+  }
 }
 
 static bool isSpecialFilename(StringRef Filename) {


### PR DESCRIPTION
The clang importer in Swift uses its own subclass of the clang
dependency collector. Because it is completely hidden in the clang
importer's implementation, we cannot subclass it from LLDB.

This is an issue for reproducers, because LLDB needs to be informed of
all the files used by clang through the Swift compiler. To solve this, I
added the ability to register a custom callback in the dependency
collector. LLDB can use this callback to be notified, without needing
access to the dependency collector's implementation.