### PR TITLE
[5.1] [FileManager] fillRealPathName even if we aren't opening the file

### DIFF
--- a/lib/Basic/FileManager.cpp
+++ b/lib/Basic/FileManager.cpp
@@ -286,6 +286,9 @@ const FileEntry *FileManager::getFile(StringRef Filename, bool openFile,
   if (UFE.File) {
     if (auto PathName = UFE.File->getName())
       fillRealPathName(&UFE, *PathName);
+  } else if (!openFile) {
+    // We should still fill the path even if we aren't opening the file.
+    fillRealPathName(&UFE, InterndFileName);
   }
   return &UFE;
 }


### PR DESCRIPTION
Follow-up to #336 to fix issues in clangd. Credit to @jkorous-apple for noticing that he'd fixed this back when it happened in upstream LLVM.

rdar://problem/52272757