### PR TITLE
tweak DirectoryWatcher to use LINK_LIBS instead of target_link_libraries.

### DIFF
--- a/lib/DirectoryWatcher/CMakeLists.txt
+++ b/lib/DirectoryWatcher/CMakeLists.txt
@@ -22,6 +22,6 @@ endif()
 
 add_clang_library(clangDirectoryWatcher
   ${DIRECTORY_WATCHER_SOURCES}
+  LINK_LIBS
+  ${DIRECTORY_WATCHER_LINK_LIBS}
   )
-
-target_link_libraries(clangDirectoryWatcher PRIVATE ${DIRECTORY_WATCHER_LINK_LIBS})


### PR DESCRIPTION
This is the root cause of the initial error in master-next build problems.

See https://ci.swift.org/view/swift-master-next/job/oss-swift-incremental-RA-linux-ubuntu-16_04-master-next/11345/console for example.