### PR TITLE
Adding sys::fs::convertFDToNativeFile(FD), to address llvm.org/D63452

### DIFF
--- a/lib/Index/IndexUnitReader.cpp
+++ b/lib/Index/IndexUnitReader.cpp
@@ -425,7 +425,8 @@ IndexUnitReader::createWithFilePath(StringRef FilePath, std::string &Error) {
     return nullptr;
   }
 
-  auto ErrOrBuf = MemoryBuffer::getOpenFile(FD, FilePath, /*FileSize=*/-1,
+  auto ErrOrBuf = MemoryBuffer::getOpenFile(sys::fs::convertFDToNativeFile(FD),
+                                            FilePath, /*FileSize=*/-1,
                                             /*RequiresNullTerminator=*/false);
   if (!ErrOrBuf) {
     raw_string_ostream(Error) << "Failed opening '" << FilePath << "': "


### PR DESCRIPTION
IndexUnitReader.cpp is not in upstream llvm. It was using an older API.