### PR TITLE
[APINotes] Adopt FileManager's error-returning APIs

### DIFF
--- a/lib/APINotes/APINotesManager.cpp
+++ b/lib/APINotes/APINotesManager.cpp
@@ -146,7 +146,8 @@ const FileEntry *APINotesManager::findAPINotesFile(const DirectoryEntry *directo
   // Look for the source API notes file.
   llvm::sys::path::append(path, 
     llvm::Twine(basename) + basenameSuffix + "." + SOURCE_APINOTES_EXTENSION);
-  return fileMgr.getFile(path, /*Open*/true);
+  auto file = fileMgr.getFile(path, /*Open*/true);
+  return file ? *file : nullptr;
 }
 
 const DirectoryEntry *APINotesManager::loadFrameworkAPINotes(
@@ -171,7 +172,7 @@ const DirectoryEntry *APINotesManager::loadFrameworkAPINotes(
                               + SOURCE_APINOTES_EXTENSION));
 
   // Try to open the APINotes file.
-  const FileEntry *APINotesFile = FileMgr.getFile(Path);
+  auto APINotesFile = FileMgr.getFile(Path);
   if (!APINotesFile)
     return nullptr;
 
@@ -183,12 +184,12 @@ const DirectoryEntry *APINotesManager::loadFrameworkAPINotes(
     llvm::sys::path::append(Path, "PrivateHeaders");
 
   // Try to access the header directory.
-  const DirectoryEntry *HeaderDir = FileMgr.getDirectory(Path);
+  auto HeaderDir = FileMgr.getDirectory(Path);
   if (!HeaderDir)
     return nullptr;
 
   // Try to load the API notes.
-  if (loadAPINotes(HeaderDir, APINotesFile))
+  if (loadAPINotes(*HeaderDir, *APINotesFile))
     return nullptr;
 
   // Success: return the header directory.
@@ -274,7 +275,7 @@ bool APINotesManager::loadCurrentModuleAPINotes(
 
         llvm::sys::path::append(path, "Headers");
         if (auto apinotesDir = fileMgr.getDirectory(path))
-          tryAPINotes(apinotesDir, /*wantPublic=*/true);
+          tryAPINotes(*apinotesDir, /*wantPublic=*/true);
 
         path.resize(pathLen);
       }
@@ -282,7 +283,7 @@ bool APINotesManager::loadCurrentModuleAPINotes(
       if (module->ModuleMapIsPrivate || hasPrivateSubmodules(module)) {
         llvm::sys::path::append(path, "PrivateHeaders");
         if (auto privateAPINotesDir = fileMgr.getDirectory(path)) {
-          tryAPINotes(privateAPINotesDir,
+          tryAPINotes(*privateAPINotesDir,
                       /*wantPublic=*/module->ModuleMapIsPrivate);
         }
       }
@@ -306,7 +307,7 @@ bool APINotesManager::loadCurrentModuleAPINotes(
   // notes search paths.
   for (const auto &searchPath : searchPaths) {
     if (auto searchDir = fileMgr.getDirectory(searchPath)) {
-      if (auto file = findAPINotesFile(searchDir, moduleName)) {
+      if (auto file = findAPINotesFile(*searchDir, moduleName)) {
         CurrentModuleReaders[0] = loadAPINotes(file).release();
         return !getCurrentModuleReaders().empty();
       }
@@ -414,8 +415,8 @@ llvm::SmallVector<APINotesReader *, 2> APINotesManager::findAPINotes(SourceLocat
 
       // If there is an API notes file here, try to load it.
       ++NumDirectoriesSearched;
-      if (const FileEntry *APINotesFile = FileMgr.getFile(APINotesPath)) {
-        if (!loadAPINotes(Dir, APINotesFile)) {
+      if (auto APINotesFile = FileMgr.getFile(APINotesPath)) {
+        if (!loadAPINotes(Dir, *APINotesFile)) {
           ++NumHeaderAPINotes;
           if (auto Reader = Readers[Dir].dyn_cast<APINotesReader *>())
             Results.push_back(Reader);
@@ -437,7 +438,8 @@ llvm::SmallVector<APINotesReader *, 2> APINotesManager::findAPINotes(SourceLocat
     if (ParentPath.empty()) {
       Dir = nullptr;
     } else {
-      Dir = FileMgr.getDirectory(ParentPath);
+      auto DirEntry = FileMgr.getDirectory(ParentPath)
+      Dir = DirEntry ? *DirEntry : nullptr;
     }
   } while (Dir);
 


### PR DESCRIPTION
In https://reviews.llvm.org/D65534, FileManager's getFile and
getDirectory APIs were updated to return errors, not just null-or-valid
pointers. Update our internal APINotes usage of FileManager for this.

Fixes rdar://53837986