### PR TITLE
[IndexStore] Update for DirectoryWatcher API change

### DIFF
--- a/lib/IndexDataStore/IndexDataStore.cpp
+++ b/lib/IndexDataStore/IndexDataStore.cpp
@@ -137,13 +137,14 @@ bool IndexDataStoreImpl::startEventListening(bool waitInitialSync, std::string &
     }
   };
 
-  DirWatcher = DirectoryWatcher::create(UnitPath.str(), OnUnitsChange,
-                                        waitInitialSync);
-  if (!DirWatcher) {
-    Error = "failed to create directory watcher";
-    return true;
+  llvm::Expected<std::unique_ptr<DirectoryWatcher>> ExpectedDirWatcher =
+      DirectoryWatcher::create(UnitPath.str(), OnUnitsChange, waitInitialSync);
+  if (!ExpectedDirWatcher) {
+      Error = llvm::toString(ExpectedDirWatcher.takeError());
+      return true;
   }
 
+  DirWatcher = std::move(ExpectedDirWatcher.get());
   return false;
 }
 


### PR DESCRIPTION
DirectoryWatcher returns an llvm::Expected after r367979. Update
IndexStore accordingly.