### PR TITLE
[DirectoryWatcher] Fix Windows stub after LLVM change

### DIFF
--- a/lib/DirectoryWatcher/windows/DirectoryWatcher-windows.cpp
+++ b/lib/DirectoryWatcher/windows/DirectoryWatcher-windows.cpp
@@ -40,9 +40,11 @@ public:
 };
 } // namespace
 
-std::unique_ptr<DirectoryWatcher> clang::DirectoryWatcher::create(
+llvm::Expected<std::unique_ptr<DirectoryWatcher>>
+clang::DirectoryWatcher::create(
     StringRef Path,
     std::function<void(llvm::ArrayRef<DirectoryWatcher::Event>, bool)> Receiver,
     bool WaitForInitialSync) {
-    return nullptr;
+  return llvm::Expected<std::unique_ptr<DirectoryWatcher>>(
+      llvm::errorCodeToError(std::make_error_code(std::errc::not_supported)));
 }


### PR DESCRIPTION
r367979 changed DirectoryWatcher::Create to return an llvm::Expected.
Adjust the Windows stub accordingly.