### PR TITLE
CodeGen: ensure 8-byte aligned String Swift CF ABI

### DIFF
--- a/lib/CodeGen/CodeGenModule.cpp
+++ b/lib/CodeGen/CodeGenModule.cpp
@@ -4360,7 +4360,10 @@ CodeGenModule::GetAddrOfConstantCFString(const StringLiteral *Literal) {
   }
   Fields.addInt(LengthTy, StringLength);
 
-  CharUnits Alignment = getPointerAlign();
+  // Swift ABI requires 8-byte alignment to ensure that the _Atomic(uint64_t) is
+  // properly aligned on 32-bit platforms.
+  CharUnits Alignment =
+      IsSwiftABI ? Context.toCharUnitsFromBits(64) : getPointerAlign();
 
   // The struct.
   GV = Fields.finishAndCreateGlobal("_unnamed_cfstring_", Alignment,

--- a/test/CodeGen/cf-runtime-abi.c
+++ b/test/CodeGen/cf-runtime-abi.c
@@ -46,15 +46,21 @@ const __NSConstantString *s = __builtin___CFStringMakeConstantString("");
 // CHECK-SWIFT-DARWIN-5_0-64: @_unnamed_cfstring_ = private global %struct.__NSConstantString_tag { i64 ptrtoint (i64* @"$s15SwiftFoundation19_NSCFConstantStringCN" to i64), i64 1, i64 1992, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @.str, i32 0, i32 0), i64 0 }
 // CHECK-SWIFT-DARWIN-5_0-32: @_unnamed_cfstring_ = private global %struct.__NSConstantString_tag { i32 ptrtoint (i32* @"$s15SwiftFoundation19_NSCFConstantStringCN" to i32), i32 1, i64 1992, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @.str, i32 0, i32 0), i32 0 }
 // CHECK-SWIFT-5_0-64: @_unnamed_cfstring_ = private global %struct.__NSConstantString_tag { i64 ptrtoint (i64* @"$s10Foundation19_NSCFConstantStringCN" to i64), i64 1, i64 1992, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @.str, i32 0, i32 0), i64 0 }
+// CHECK-SWIFT-5_0-64-SAME: align 8
 // CHECK-SWIFT-5_0-32: @_unnamed_cfstring_ = private global %struct.__NSConstantString_tag { i32 ptrtoint (i32* @"$s10Foundation19_NSCFConstantStringCN" to i32), i32 1, i64 1992, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @.str, i32 0, i32 0), i32 0 }
+// CHECK-SWIFT-5_0-32-SAME: align 8
 
 // CHECK-SWIFT-DARWIN-4_2-64: @_unnamed_cfstring_ = private global %struct.__NSConstantString_tag { i64 ptrtoint (i64* @"$S15SwiftFoundation19_NSCFConstantStringCN" to i64), i64 1, i64 1992, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @.str, i32 0, i32 0), i32 0 }
 // CHECK-SWIFT-DARWIN-4_2-32: @_unnamed_cfstring_ = private global %struct.__NSConstantString_tag { i32 ptrtoint (i32* @"$S15SwiftFoundation19_NSCFConstantStringCN" to i32), i32 1, i64 1992, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @.str, i32 0, i32 0), i32 0 }
 // CHECK-SWIFT-4_2-64: @_unnamed_cfstring_ = private global %struct.__NSConstantString_tag { i64 ptrtoint (i64* @"$S10Foundation19_NSCFConstantStringCN" to i64), i64 1, i64 1992, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @.str, i32 0, i32 0), i32 0 }
+// CHECK-SWIFT-4_2-64-SAME: align 8
 // CHECK-SWIFT-4_2-32: @_unnamed_cfstring_ = private global %struct.__NSConstantString_tag { i32 ptrtoint (i32* @"$S10Foundation19_NSCFConstantStringCN" to i32), i32 1, i64 1992, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @.str, i32 0, i32 0), i32 0 }
+// CHECK-SWIFT-4_2-32-SAME: align 8
 
 // CHECK-SWIFT-DARWIN-4_1-64: @_unnamed_cfstring_ = private global %struct.__NSConstantString_tag { i64 ptrtoint (i64* @__T015SwiftFoundation19_NSCFConstantStringCN to i64), i64 5, i64 1992, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @.str, i32 0, i32 0), i32 0 }
 // CHECK-SWIFT-DARWIN-4_1-32: @_unnamed_cfstring_ = private global %struct.__NSConstantString_tag { i32 ptrtoint (i32* @__T015SwiftFoundation19_NSCFConstantStringCN to i32), i32 5, i64 1992, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @.str, i32 0, i32 0), i32 0 }
 // CHECK-SWIFT-4_1-64: @_unnamed_cfstring_ = private global %struct.__NSConstantString_tag { i64 ptrtoint (i64* @__T010Foundation19_NSCFConstantStringCN to i64), i64 5, i64 1992, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @.str, i32 0, i32 0), i32 0 }
+// CHECK-SWIFT-4_1-64-SAME: align 8
 // CHECK-SWIFT-4_1-32: @_unnamed_cfstring_ = private global %struct.__NSConstantString_tag { i32 ptrtoint (i32* @__T010Foundation19_NSCFConstantStringCN to i32), i32 5, i64 1992, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @.str, i32 0, i32 0), i32 0 }
+// CHECK-SWIFT-4_1-32-SAME: align 8
 


### PR DESCRIPTION
CFStrings should be 8-byte aligned when built for the Swift CF runtime
ABI as the atomic CF info field must be properly aligned.  This is a
problem on 32-bit platforms which would give the structure 4-byte
alignment rather than 8-byte alignment.

git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@368471 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit ee5531b2162e8d696928cbd48f58d92740c1015e)