### PR TITLE
Mark indexstore enum flag types with flag_enum attribute

### DIFF
--- a/include/clang/Index/IndexDataStoreSymbolUtils.h
+++ b/include/clang/Index/IndexDataStoreSymbolUtils.h
@@ -42,10 +42,10 @@ indexstore_symbol_subkind_t getIndexStoreSubKind(SymbolSubKind K);
 indexstore_symbol_language_t getIndexStoreLang(SymbolLanguage L);
 
 /// Map a SymbolPropertySet to its indexstore representation.
-uint64_t getIndexStoreProperties(SymbolPropertySet Props);
+indexstore_symbol_property_t getIndexStoreProperties(SymbolPropertySet Props);
 
 /// Map a SymbolRoleSet to its indexstore representation.
-uint64_t getIndexStoreRoles(SymbolRoleSet Roles);
+indexstore_symbol_role_t getIndexStoreRoles(SymbolRoleSet Roles);
 
 } // end namespace index
 } // end namespace clang

--- a/include/indexstore/indexstore.h
+++ b/include/indexstore/indexstore.h
@@ -84,6 +84,12 @@
 # define INDEXSTORE_NOESCAPE
 #endif
 
+#if __has_attribute(flag_enum)
+# define INDEXSTORE_OPTIONS __attribute__((flag_enum))
+#else
+# define INDEXSTORE_OPTIONS
+#endif
+
 INDEXSTORE_BEGIN_DECLS
 
 typedef void *indexstore_error_t;
@@ -266,7 +272,7 @@ typedef enum {
   INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORMODIFY = 1015,
 } indexstore_symbol_subkind_t;
 
-typedef enum {
+typedef enum INDEXSTORE_OPTIONS {
   INDEXSTORE_SYMBOL_PROPERTY_GENERIC                          = 1 << 0,
   INDEXSTORE_SYMBOL_PROPERTY_TEMPLATE_PARTIAL_SPECIALIZATION  = 1 << 1,
   INDEXSTORE_SYMBOL_PROPERTY_TEMPLATE_SPECIALIZATION          = 1 << 2,
@@ -286,7 +292,7 @@ typedef enum {
   INDEXSTORE_SYMBOL_LANG_SWIFT = 100,
 } indexstore_symbol_language_t;
 
-typedef enum {
+typedef enum INDEXSTORE_OPTIONS {
   INDEXSTORE_SYMBOL_ROLE_DECLARATION  = 1 << 0,
   INDEXSTORE_SYMBOL_ROLE_DEFINITION   = 1 << 1,
   INDEXSTORE_SYMBOL_ROLE_REFERENCE    = 1 << 2,
@@ -320,13 +326,13 @@ indexstore_symbol_get_kind(indexstore_symbol_t);
 INDEXSTORE_PUBLIC indexstore_symbol_subkind_t
 indexstore_symbol_get_subkind(indexstore_symbol_t);
 
-INDEXSTORE_PUBLIC uint64_t
+INDEXSTORE_PUBLIC indexstore_symbol_property_t
 indexstore_symbol_get_properties(indexstore_symbol_t);
 
-INDEXSTORE_PUBLIC uint64_t
+INDEXSTORE_PUBLIC indexstore_symbol_role_t
 indexstore_symbol_get_roles(indexstore_symbol_t);
 
-INDEXSTORE_PUBLIC uint64_t
+INDEXSTORE_PUBLIC indexstore_symbol_role_t
 indexstore_symbol_get_related_roles(indexstore_symbol_t);
 
 INDEXSTORE_PUBLIC indexstore_string_ref_t
@@ -340,7 +346,7 @@ indexstore_symbol_get_codegen_name(indexstore_symbol_t);
 
 typedef void *indexstore_symbol_relation_t;
 
-INDEXSTORE_PUBLIC uint64_t
+INDEXSTORE_PUBLIC indexstore_symbol_role_t
 indexstore_symbol_relation_get_roles(indexstore_symbol_relation_t);
 
 INDEXSTORE_PUBLIC indexstore_symbol_t
@@ -362,7 +368,7 @@ indexstore_occurrence_relations_apply_f(indexstore_occurrence_t,
                                         void *context,
         INDEXSTORE_NOESCAPE bool(*applier)(void *context, indexstore_symbol_relation_t symbol_rel));
 
-INDEXSTORE_PUBLIC uint64_t
+INDEXSTORE_PUBLIC indexstore_symbol_role_t
 indexstore_occurrence_get_roles(indexstore_occurrence_t);
 
 INDEXSTORE_PUBLIC void

--- a/include/indexstore/indexstore.h
+++ b/include/indexstore/indexstore.h
@@ -85,9 +85,25 @@
 #endif
 
 #if __has_attribute(flag_enum)
-# define INDEXSTORE_OPTIONS __attribute__((flag_enum))
+# define _INDEXSTORE_FLAG_ENUM __attribute__((flag_enum))
 #else
-# define INDEXSTORE_OPTIONS
+# define _INDEXSTORE_FLAG_ENUM
+#endif
+
+#if __has_attribute(enum_extensibility)
+# define _INDEXSTORE_OPEN_ENUM __attribute__((enum_extensibility(open)))
+#else
+# define _INDEXSTORE_OPEN_ENUM
+#endif
+
+#define _INDEXSTORE_OPTIONS_ATTRS _INDEXSTORE_OPEN_ENUM _INDEXSTORE_FLAG_ENUM
+
+#if __has_extension(cxx_strong_enums)
+# define INDEXSTORE_OPTIONS(_name, _type) enum _INDEXSTORE_OPTIONS_ATTRS _name : _type
+#elif __has_feature(objc_fixed_enum)
+# define INDEXSTORE_OPTIONS(_name, _type) typedef enum _INDEXSTORE_OPTIONS_ATTRS _name : _type _name; enum _INDEXSTORE_OPTIONS_ATTRS _name : _type
+#else
+# define INDEXSTORE_OPTIONS(_name, _type) typedef _type _name; enum _INDEXSTORE_OPTIONS_ATTRS
 #endif
 
 INDEXSTORE_BEGIN_DECLS
@@ -272,7 +288,7 @@ typedef enum {
   INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORMODIFY = 1015,
 } indexstore_symbol_subkind_t;
 
-typedef enum INDEXSTORE_OPTIONS {
+INDEXSTORE_OPTIONS(indexstore_symbol_property_t, uint64_t) {
   INDEXSTORE_SYMBOL_PROPERTY_GENERIC                          = 1 << 0,
   INDEXSTORE_SYMBOL_PROPERTY_TEMPLATE_PARTIAL_SPECIALIZATION  = 1 << 1,
   INDEXSTORE_SYMBOL_PROPERTY_TEMPLATE_SPECIALIZATION          = 1 << 2,
@@ -282,7 +298,7 @@ typedef enum INDEXSTORE_OPTIONS {
   INDEXSTORE_SYMBOL_PROPERTY_GKINSPECTABLE                    = 1 << 6,
   INDEXSTORE_SYMBOL_PROPERTY_LOCAL                            = 1 << 7,
   INDEXSTORE_SYMBOL_PROPERTY_PROTOCOL_INTERFACE               = 1 << 8,
-} indexstore_symbol_property_t;
+};
 
 typedef enum {
   INDEXSTORE_SYMBOL_LANG_C = 0,
@@ -292,7 +308,7 @@ typedef enum {
   INDEXSTORE_SYMBOL_LANG_SWIFT = 100,
 } indexstore_symbol_language_t;
 
-typedef enum INDEXSTORE_OPTIONS {
+INDEXSTORE_OPTIONS(indexstore_symbol_role_t, uint64_t) {
   INDEXSTORE_SYMBOL_ROLE_DECLARATION  = 1 << 0,
   INDEXSTORE_SYMBOL_ROLE_DEFINITION   = 1 << 1,
   INDEXSTORE_SYMBOL_ROLE_REFERENCE    = 1 << 2,
@@ -315,7 +331,7 @@ typedef enum INDEXSTORE_OPTIONS {
   INDEXSTORE_SYMBOL_ROLE_REL_CONTAINEDBY = 1 << 16,
   INDEXSTORE_SYMBOL_ROLE_REL_IBTYPEOF    = 1 << 17,
   INDEXSTORE_SYMBOL_ROLE_REL_SPECIALIZATIONOF = 1 << 18,
-} indexstore_symbol_role_t;
+};
 
 INDEXSTORE_PUBLIC indexstore_symbol_language_t
 indexstore_symbol_get_language(indexstore_symbol_t);

--- a/include/indexstore/indexstore.h
+++ b/include/indexstore/indexstore.h
@@ -85,25 +85,23 @@
 #endif
 
 #if __has_attribute(flag_enum)
-# define _INDEXSTORE_FLAG_ENUM __attribute__((flag_enum))
+# define INDEXSTORE_FLAG_ENUM_ATTR __attribute__((flag_enum))
 #else
-# define _INDEXSTORE_FLAG_ENUM
+# define INDEXSTORE_FLAG_ENUM_ATTR
 #endif
 
 #if __has_attribute(enum_extensibility)
-# define _INDEXSTORE_OPEN_ENUM __attribute__((enum_extensibility(open)))
+# define INDEXSTORE_OPEN_ENUM_ATTR __attribute__((enum_extensibility(open)))
 #else
-# define _INDEXSTORE_OPEN_ENUM
+# define INDEXSTORE_OPEN_ENUM_ATTR
 #endif
 
-#define _INDEXSTORE_OPTIONS_ATTRS _INDEXSTORE_OPEN_ENUM _INDEXSTORE_FLAG_ENUM
+#define INDEXSTORE_OPTIONS_ATTRS INDEXSTORE_OPEN_ENUM_ATTR INDEXSTORE_FLAG_ENUM_ATTR
 
-#if __has_extension(cxx_strong_enums)
-# define INDEXSTORE_OPTIONS(_name, _type) enum _INDEXSTORE_OPTIONS_ATTRS _name : _type
-#elif __has_feature(objc_fixed_enum)
-# define INDEXSTORE_OPTIONS(_name, _type) typedef enum _INDEXSTORE_OPTIONS_ATTRS _name : _type _name; enum _INDEXSTORE_OPTIONS_ATTRS _name : _type
+#if __has_extension(cxx_strong_enums) || __has_feature(objc_fixed_enum)
+# define INDEXSTORE_OPTIONS(_type, _name) enum INDEXSTORE_OPTIONS_ATTRS _name : _type _name; enum INDEXSTORE_OPTIONS_ATTRS _name : _type
 #else
-# define INDEXSTORE_OPTIONS(_name, _type) typedef _type _name; enum _INDEXSTORE_OPTIONS_ATTRS
+# define INDEXSTORE_OPTIONS(_type, _name) _type _name; enum INDEXSTORE_OPTIONS_ATTRS
 #endif
 
 INDEXSTORE_BEGIN_DECLS
@@ -288,7 +286,7 @@ typedef enum {
   INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORMODIFY = 1015,
 } indexstore_symbol_subkind_t;
 
-INDEXSTORE_OPTIONS(indexstore_symbol_property_t, uint64_t) {
+typedef INDEXSTORE_OPTIONS(uint64_t, indexstore_symbol_property_t) {
   INDEXSTORE_SYMBOL_PROPERTY_GENERIC                          = 1 << 0,
   INDEXSTORE_SYMBOL_PROPERTY_TEMPLATE_PARTIAL_SPECIALIZATION  = 1 << 1,
   INDEXSTORE_SYMBOL_PROPERTY_TEMPLATE_SPECIALIZATION          = 1 << 2,
@@ -308,7 +306,7 @@ typedef enum {
   INDEXSTORE_SYMBOL_LANG_SWIFT = 100,
 } indexstore_symbol_language_t;
 
-INDEXSTORE_OPTIONS(indexstore_symbol_role_t, uint64_t) {
+typedef INDEXSTORE_OPTIONS(uint64_t, indexstore_symbol_role_t) {
   INDEXSTORE_SYMBOL_ROLE_DECLARATION  = 1 << 0,
   INDEXSTORE_SYMBOL_ROLE_DEFINITION   = 1 << 1,
   INDEXSTORE_SYMBOL_ROLE_REFERENCE    = 1 << 2,

--- a/lib/Index/IndexDataStoreUtils.cpp
+++ b/lib/Index/IndexDataStoreUtils.cpp
@@ -410,7 +410,7 @@ indexstore_symbol_language_t index::getIndexStoreLang(SymbolLanguage L) {
 }
 
 /// Map a SymbolPropertySet to its indexstore representation.
-uint64_t index::getIndexStoreProperties(SymbolPropertySet Props) {
+indexstore_symbol_property_t index::getIndexStoreProperties(SymbolPropertySet Props) {
   uint64_t storeProp = 0;
   applyForEachSymbolProperty(Props, [&](SymbolProperty prop) {
     switch (prop) {
@@ -443,11 +443,11 @@ uint64_t index::getIndexStoreProperties(SymbolPropertySet Props) {
       break;
     }
   });
-  return storeProp;
+  return static_cast<indexstore_symbol_property_t>(storeProp);
 }
 
 /// Map a SymbolRoleSet to its indexstore representation.
-uint64_t index::getIndexStoreRoles(SymbolRoleSet Roles) {
+indexstore_symbol_role_t index::getIndexStoreRoles(SymbolRoleSet Roles) {
   uint64_t storeRoles = 0;
   applyForEachSymbolRole(Roles, [&](SymbolRole role) {
     switch (role) {
@@ -513,5 +513,5 @@ uint64_t index::getIndexStoreRoles(SymbolRoleSet Roles) {
       break;
     }
   });
-  return storeRoles;
+  return static_cast<indexstore_symbol_role_t>(storeRoles);
 }

--- a/tools/IndexStore/IndexStore.cpp
+++ b/tools/IndexStore/IndexStore.cpp
@@ -321,17 +321,17 @@ indexstore_symbol_get_language(indexstore_symbol_t sym) {
   return getIndexStoreLang(static_cast<IndexRecordDecl *>(sym)->SymInfo.Lang);
 }
 
-uint64_t
+indexstore_symbol_property_t
 indexstore_symbol_get_properties(indexstore_symbol_t sym) {
   return getIndexStoreProperties(static_cast<IndexRecordDecl *>(sym)->SymInfo.Properties);
 }
 
-uint64_t
+indexstore_symbol_role_t
 indexstore_symbol_get_roles(indexstore_symbol_t sym) {
   return getIndexStoreRoles(static_cast<IndexRecordDecl *>(sym)->Roles);
 }
 
-uint64_t
+indexstore_symbol_role_t
 indexstore_symbol_get_related_roles(indexstore_symbol_t sym) {
   return getIndexStoreRoles(static_cast<IndexRecordDecl *>(sym)->RelatedRoles);
 }
@@ -354,7 +354,7 @@ indexstore_symbol_get_codegen_name(indexstore_symbol_t sym) {
   return toIndexStoreString(D->CodeGenName);
 }
 
-uint64_t
+indexstore_symbol_role_t
 indexstore_symbol_relation_get_roles(indexstore_symbol_relation_t sym_rel) {
   return getIndexStoreRoles(static_cast<IndexRecordRelation *>(sym_rel)->Roles);
 }
@@ -394,7 +394,7 @@ indexstore_occurrence_relations_apply_f(indexstore_occurrence_t occur,
   return true;
 }
 
-uint64_t
+indexstore_symbol_role_t
 indexstore_occurrence_get_roles(indexstore_occurrence_t occur) {
   return getIndexStoreRoles(static_cast<IndexRecordOccurrence*>(occur)->Roles);
 }


### PR DESCRIPTION
Duplicate of https://github.com/apple/swift-clang/pull/288 targeting `apple/stable/20190619`

<hr/>

Adds useful compiler attributes to the two indexstore bit flag types: `indexstore_symbol_property_t` and `indexstore_symbol_role_t`.

These `enum` declarations are now declared with the following features:

1. Defined as 64bit ints using C++ or ObjC sized enums, otherwise falling back to a `typedef`
2. Marked with `flag_enum` attribute, if available
3. Marked with `enum_extensibility(open)` attribute, if available

Additionally, the functions that return these types now return the `enum` itself or the fallback `typedef`. Previously these functions returned an explicit `uint64_t`.

The motivation for these changes is for use from Swift. Now, these bit flags are imported into Swift as [`OptionSet`](https://developer.apple.com/documentation/swift/optionset)s.