### PR TITLE
[CrashReproducer] Handle indexing turned on with CLANG_PROJECT_INDEX_PATH.

### DIFF
--- a/include/clang/Driver/Job.h
+++ b/include/clang/Driver/Job.h
@@ -31,11 +31,12 @@ class Tool;
 struct CrashReportInfo {
   StringRef Filename;
   StringRef VFSPath;
-  StringRef IndexStorePath;
+  bool HaveIndexStorePath;
 
   CrashReportInfo(StringRef Filename, StringRef VFSPath,
-                  StringRef IndexStorePath)
-      : Filename(Filename), VFSPath(VFSPath), IndexStorePath(IndexStorePath) {}
+                  bool HaveIndexStorePath)
+      : Filename(Filename), VFSPath(VFSPath),
+        HaveIndexStorePath(HaveIndexStorePath) {}
 };
 
 /// Command - An executable path/name and argument vector to

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1380,7 +1380,7 @@ void Driver::generateCompilationDiagnostics(
   // Assume associated files are based off of the first temporary file.
   CrashReportInfo CrashInfo(
       TempFiles[0], VFS,
-      C.getArgs().getLastArgValue(options::OPT_index_store_path));
+      llvm::is_contained(Cmd.getArguments(), StringRef("-index-store-path")));
 
   llvm::SmallString<128> Script(CrashInfo.Filename);
   llvm::sys::path::replace_extension(Script, "sh");

--- a/lib/Driver/Job.cpp
+++ b/lib/Driver/Job.cpp
@@ -229,7 +229,6 @@ void Command::Print(raw_ostream &OS, const char *Terminator, bool Quote,
   }
 
   bool HaveCrashVFS = CrashInfo && !CrashInfo->VFSPath.empty();
-  bool HaveIndexStorePath = CrashInfo && !CrashInfo->IndexStorePath.empty();
   for (size_t i = 0, e = Args.size(); i < e; ++i) {
     const char *const Arg = Args[i];
 
@@ -293,7 +292,7 @@ void Command::Print(raw_ostream &OS, const char *Terminator, bool Quote,
     printArg(OS, ModCachePath, Quote);
   }
 
-  if (CrashInfo && HaveIndexStorePath) {
+  if (CrashInfo && CrashInfo->HaveIndexStorePath) {
     SmallString<128> IndexStoreDir;
 
     if (HaveCrashVFS) {

--- a/test/Modules/crash-index-store-path.m
+++ b/test/Modules/crash-index-store-path.m
@@ -14,6 +14,12 @@
 // RUN: %clang -fsyntax-only %s -index-store-path %t/index \
 // RUN:     2>&1 | FileCheck --check-prefix=CHECK %s
 // RUN: FileCheck --check-prefix=CHECKSH %s -input-file %t/crash-index-*.sh
+
+// Turn on indexing with an environment variable.
+// RUN: rm -rf %t
+// RUN: not env FORCE_CLANG_DIAGNOSTICS_CRASH= TMPDIR=%t TEMP=%t TMP=%t CLANG_PROJECT_INDEX_PATH=%t/index \
+// RUN: %clang -fsyntax-only %s 2>&1 | FileCheck --check-prefix=CHECK %s
+// RUN: FileCheck --check-prefix=CHECKSH %s -input-file %t/crash-index-*.sh
 int foo() { return 0; }
 
 // CHECKMOD: Preprocessed source(s) and associated run script(s) are located at:


### PR DESCRIPTION
Crash reproducer is checking the driver's arguments for
`-index-store-path` and in case of the environment variable, this
argument is absent. So the generated reproducer incorrectly won't run
the indexer.

Fix by checking the arguments of the failed -cc1 command for
`-index-store-path`.

rdar://problem/48830606