### PR TITLE
[DirectoryWatcher] Fix cross-compilation checking fs_event availability.

### DIFF
--- a/lib/DirectoryWatcher/CMakeLists.txt
+++ b/lib/DirectoryWatcher/CMakeLists.txt
@@ -2,6 +2,8 @@ include(CheckIncludeFiles)
 
 set(LLVM_LINK_COMPONENTS support)
 
+CHECK_SYMBOL_EXISTS("FSEventStreamRef" "CoreServices/CoreServices.h" HAS_FS_EVENTS)
+
 add_clang_library(clangDirectoryWatcher
   DirectoryWatcher.cpp
   )

--- a/lib/DirectoryWatcher/DirectoryWatcher.cpp
+++ b/lib/DirectoryWatcher/DirectoryWatcher.cpp
@@ -92,7 +92,7 @@ struct DirectoryScan {
 # define __has_include(x) 0
 #endif
 
-#if __has_include(<CoreServices/CoreServices.h>)
+#if HAS_FS_EVENTS
 # include "DirectoryWatcher-mac.inc.h"
 #elif __has_include(<sys/inotify.h>)
 # include "DirectoryWatcher-linux.inc.h"


### PR DESCRIPTION
Some platforms have the header but don't have support for fs_event.