### PR TITLE
[DirectoryWatcher] Fix cross-compilation checking fs_event availability.

### DIFF
--- a/lib/DirectoryWatcher/DirectoryWatcher.cpp
+++ b/lib/DirectoryWatcher/DirectoryWatcher.cpp
@@ -92,7 +92,11 @@ struct DirectoryScan {
 # define __has_include(x) 0
 #endif
 
-#if __has_include(<CoreServices/CoreServices.h>)
+#if !defined(__is_target_os)
+#define __is_target_os(x) 0
+#endif
+
+#if __is_target_os(macos)
 # include "DirectoryWatcher-mac.inc.h"
 #elif __has_include(<sys/inotify.h>)
 # include "DirectoryWatcher-linux.inc.h"


### PR DESCRIPTION
Some platforms have the header but don't have support for fs_event.