### PR TITLE
[CMake] Clang: Don't use object libraries with Xcode

### DIFF
--- a/cmake/modules/AddClang.cmake
+++ b/cmake/modules/AddClang.cmake
@@ -86,9 +86,13 @@ macro(add_clang_library name)
     # llvm_add_library ignores BUILD_SHARED_LIBS if STATIC is explicitly set,
     # so we need to handle it here.
     if(BUILD_SHARED_LIBS)
-      set(LIBTYPE SHARED OBJECT)
+      set(LIBTYPE SHARED)
     else()
-      set(LIBTYPE STATIC OBJECT)
+      set(LIBTYPE STATIC)
+    endif()
+    if(NOT XCODE)
+      # The Xcode generator doesn't handle object libraries correctly.
+      list(APPEND LIBTYPE OBJECT)
     endif()
     set_property(GLOBAL APPEND PROPERTY CLANG_STATIC_LIBS ${name})
   endif()

--- a/tools/clang-shlib/CMakeLists.txt
+++ b/tools/clang-shlib/CMakeLists.txt
@@ -6,7 +6,13 @@ endif()
 get_property(clang_libs GLOBAL PROPERTY CLANG_STATIC_LIBS)
 
 foreach (lib ${clang_libs})
-  list(APPEND _OBJECTS $<TARGET_OBJECTS:obj.${lib}>)
+  if(XCODE)
+    # Xcode doesn't support object libraries, so we have to trick it into
+    # linking the static libraries instead.
+    list(APPEND _DEPS "-force_load" ${lib})
+  else()
+    list(APPEND _OBJECTS $<TARGET_OBJECTS:obj.${lib}>)
+  endif()
   list(APPEND _DEPS $<TARGET_PROPERTY:${lib},INTERFACE_LINK_LIBRARIES>)
   list(APPEND _DEPS $<TARGET_PROPERTY:${lib},LINK_LIBRARIES>)
 endforeach ()


### PR DESCRIPTION
Cherry-picked from https://reviews.llvm.org/D68430. Undoes some of the effects of https://reviews.llvm.org/D61909 when using the Xcode CMake generator—it doesn't handle object libraries correctly at all. Attempts to still honor `BUILD_SHARED_LIBS` for Xcode, but I didn't actually test it. Should have no effect on non-Xcode generators.